### PR TITLE
Rename "Show tool bar" option to "Show tag list"

### DIFF
--- a/app/frontend/components/options_menu/options_menu.js
+++ b/app/frontend/components/options_menu/options_menu.js
@@ -60,7 +60,7 @@ class OptionsMenu {
       openVerseListsInNewTabByDefault = true;
     }
 
-    this._toolBarOption = this.initConfigOption('showToolBarOption', () => { this.showOrHideToolBarBasedOnOption(); }, toolBarcheckedByDefault);
+    this._toolBarOption = this.initConfigOption('showTagListOption', () => { this.showOrHideToolBarBasedOnOption(); }, toolBarcheckedByDefault);
     this._bookIntroOption = this.initConfigOption('showBookIntroOption', () => { this.showOrHideBookIntroductionBasedOnOption(); });
     this._sectionTitleOption = this.initConfigOption('showSectionTitleOption', () => { this.showOrHideSectionTitlesBasedOnOption(); });
     this._xrefsOption = this.initConfigOption('showXrefsOption', () => { this.showOrHideXrefsBasedOnOption(); });

--- a/app/frontend/components/options_menu/options_menu.js
+++ b/app/frontend/components/options_menu/options_menu.js
@@ -52,15 +52,15 @@ class OptionsMenu {
       app_controller.openModuleSettingsAssistant('DICT'); 
     });
 
-    var toolBarcheckedByDefault = true;
+    var tagListOptionCheckedByDefault = true;
     var openVerseListsInNewTabByDefault = false;
 
     if (this.platformHelper.isCordova()) {
-      toolBarcheckedByDefault = false;
+      tagListOptionCheckedByDefault = false;
       openVerseListsInNewTabByDefault = true;
     }
 
-    this._toolBarOption = this.initConfigOption('showTagListOption', () => { this.showOrHideToolBarBasedOnOption(); }, toolBarcheckedByDefault);
+    this._tagListOption = this.initConfigOption('showTagListOption', () => { this.showOrHideToolBarBasedOnOption(); }, tagListOptionCheckedByDefault);
     this._bookIntroOption = this.initConfigOption('showBookIntroOption', () => { this.showOrHideBookIntroductionBasedOnOption(); });
     this._sectionTitleOption = this.initConfigOption('showSectionTitleOption', () => { this.showOrHideSectionTitlesBasedOnOption(); });
     this._xrefsOption = this.initConfigOption('showXrefsOption', () => { this.showOrHideXrefsBasedOnOption(); });
@@ -196,7 +196,7 @@ class OptionsMenu {
     var currentToolBar = $('#bible-browser-toolbox');
     var updated = false;
 
-    if (this._toolBarOption.isChecked) {
+    if (this._tagListOption.isChecked) {
       updated = app_controller.tag_assignment_menu.moveTagAssignmentList(false);
       if (updated || currentToolBar.is(':hidden')) {
         currentToolBar.show();

--- a/features/006_notes.feature
+++ b/features/006_notes.feature
@@ -26,7 +26,7 @@ Feature: Adding, viewing and editing notes
 
   @remove-last-note-after-scenario
   Scenario: Adding a note to a book
-    Given I have notes displayed
+    Given I have the notes displayed
     And I click on "Ephesians" note
     And I enter markdown text
     ```
@@ -47,8 +47,8 @@ Feature: Adding, viewing and editing notes
     And the note assigned to "Ephesians" has 3 list items
 
   Scenario: Adding a note to a verse
-    Given I have notes hidden
-    And I have indicators displayed
+    Given I have the notes hidden
+    And I have the indicators displayed
     And I click on note indicator for the verse "Ephesians 1:2"
     And I enter markdown text
     ```
@@ -60,8 +60,8 @@ Feature: Adding, viewing and editing notes
 
   @remove-last-note-after-scenario
   Scenario: Cancel verse note editing
-    Given I have notes hidden
-    And I have indicators displayed
+    Given I have the notes hidden
+    And I have the indicators displayed
     And the note assigned to "Ephesians 1:2" in the database starts with text "**Grace and peace"
     And the note assigned to "Ephesians 1:2" has "strong" text "Grace and peace"
     And I click on "Ephesians 1:2" note

--- a/features/007_locale_change.feature
+++ b/features/007_locale_change.feature
@@ -23,10 +23,10 @@ Feature: Change app language (locale)
   Background:
     Given I open the book selection menu
     And I select the book Ezra
-    And I have toolbar displayed
-    And I have dictionary displayed
-    And I have navigation displayed
-    And I have current tab search displayed
+    And I have the taglist displayed
+    And I have the dictionary displayed
+    And I have the navigation displayed
+    And I have the current tab search displayed
 
   Scenario Outline:: Switch app locale
     Given I open the options dialog

--- a/features/steps/display_options.js
+++ b/features/steps/display_options.js
@@ -1,0 +1,36 @@
+/* This file is part of Ezra Bible App.
+
+   Copyright (C) 2019 - 2021 Ezra Bible App Development Team <contact@ezrabibleapp.net>
+
+   Ezra Bible App is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
+
+   Ezra Bible App is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Ezra Bible App. See the file LICENSE.
+   If not, see <http://www.gnu.org/licenses/>. */
+
+const { Given } = require("cucumber");
+const spectronHelper = require('../helpers/spectron_helper.js');
+
+Given('I have the {display_option} {state}', { timeout: 40 * 1000 }, async function (displayOptionSelector, state) {
+  const configOption = await spectronHelper.getWebClient().$(displayOptionSelector);
+  const checkbox = await configOption.$('.toggle-config-option-switch');
+  const checked = await checkbox.getAttribute('checked');
+
+  if (state && !checked || !state && checked) {
+    const verseListTabs = await spectronHelper.getWebClient().$('#verse-list-tabs-1');
+    const displayOptionsButton = await verseListTabs.$('.display-options-button');
+
+    await displayOptionsButton.click();
+    await spectronHelper.sleep(500);
+    await checkbox.click();
+    await spectronHelper.sleep(500);
+  }
+});

--- a/features/steps/notes.js
+++ b/features/steps/notes.js
@@ -22,22 +22,6 @@ const spectronHelper = require('../helpers/spectron_helper.js');
 const dbHelper = require("../helpers/db_helper.js");
 const uiHelper = require("../helpers/ui_helper.js");
 
-
-Given('I have {display_option} {state}', { timeout: 40 * 1000 }, async function (displayOptionSelector, state) {
-  const configOption = await spectronHelper.getWebClient().$(displayOptionSelector);
-  const checkbox = await configOption.$('.toggle-config-option-switch');
-  const checked = await checkbox.getAttribute('checked');
-  if (state && !checked || !state && checked) {
-    const verseListTabs = await spectronHelper.getWebClient().$('#verse-list-tabs-1');
-    const displayOptionsButton = await verseListTabs.$('.display-options-button');
-
-    await displayOptionsButton.click();
-    await spectronHelper.sleep(500);
-    await checkbox.click();
-    await spectronHelper.sleep(500);
-  }
-});
-
 Given('I click on {string} note', async function (verseReference) {
   var verseBox = await uiHelper.getVerseBox(verseReference);
   var classes = await verseBox.getAttribute('class');

--- a/features/support/parameter_types.js
+++ b/features/support/parameter_types.js
@@ -56,7 +56,7 @@ defineParameterType({
       case 'footnotes':
         return '#showFootnotesOption';
       case 'toolbar':
-        return '#showToolBarOption';
+        return '#showTagListOption';
       case 'dictionary': 
         return '#showDictionaryOption';
       case 'navigation':

--- a/features/support/parameter_types.js
+++ b/features/support/parameter_types.js
@@ -42,7 +42,7 @@ defineParameterType({
 
 defineParameterType({
   name: 'display_option',
-  regexp: /tags|notes|indicators|xrefs|footnotes|toolbar|dictionary|navigation|current tab search/,
+  regexp: /tags|notes|indicators|xrefs|footnotes|taglist|dictionary|navigation|current tab search/,
   transformer: s => {
     switch (s) {
       case 'tags':
@@ -55,7 +55,7 @@ defineParameterType({
         return '#showXrefsOption';
       case 'footnotes':
         return '#showFootnotesOption';
-      case 'toolbar':
+      case 'taglist':
         return '#showTagListOption';
       case 'dictionary': 
         return '#showDictionaryOption';

--- a/html/display_options_menu.html
+++ b/html/display_options_menu.html
@@ -15,7 +15,7 @@
 <div class="options-group">
   <div class="options-header" i18n="bible-browser.bible-browser-layout"></div>
 
-  <config-option id="showToolBarOption" settingsKey="showToolBar" label="bible-browser.show-tool-bar" checkedByDefault="true"></config-option>
+  <config-option id="showTagListOption" settingsKey="showToolBar" label="bible-browser.show-tag-list" checkedByDefault="true"></config-option>
   <config-option id="showDictionaryOption" settingsKey="showStrongs" label="bible-browser.show-dictionary" checkedByDefault="false"></config-option>
   <config-option id="useTagsColumnOption" settingsKey="useTagsColumn" label="bible-browser.use-tags-column" checkedByDefault="false"></config-option>
   <config-option id="showBookChapterNavigationOption" settingsKey="showBookChapterNavigation" label="bible-browser.show-book-chapter-navigation" checkedByDefault="true"></config-option>

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -257,7 +257,7 @@
     "display": "Darstellung",
     "text-options": "Textoptionen",
     "bible-browser-layout": "Bibelbrowser Layout",
-    "show-tool-bar": "Zeige Werkzeugleiste",
+    "show-tag-list": "Show tag list",
     "show-book-intro": "Zeige Bucheinleitung",
     "show-section-titles": "Zeige Überschriften",
     "show-xrefs": "Zeige Parallelstellen",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -265,7 +265,7 @@
     "display": "Display",
     "text-options": "Text options",
     "bible-browser-layout": "Bible browser layout",
-    "show-tool-bar": "Show tool bar",
+    "show-tag-list": "Show tag list",
     "show-book-intro": "Show book introduction",
     "show-section-titles": "Show section titles",
     "show-xrefs": "Show cross references",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -265,7 +265,7 @@
     "display": "Pantalla",
     "text-options": "Opciones del texto",
     "bible-browser-layout": "Disposición del navegador bíblico",
-    "show-tool-bar": "Mostrar barra de herramientas",
+    "show-tag-list": "Show tag list",
     "show-book-intro": "Mostrar introducción del libro",
     "show-section-titles": "Mostrar título de secciones",
     "show-xrefs": "Mostrar referencias cruzadas",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -265,7 +265,7 @@
     "display": "Affichage",
     "text-options": "Options de texte",
     "bible-browser-layout": "Mise en page du navigateur Biblique",
-    "show-tool-bar": "Afficher la barre d'outil'",
+    "show-tag-list": "Show tag list",
     "show-book-intro": "Afficher l'introduction du livre",
     "show-section-titles": "Montrer les titres de sections",
     "show-xrefs": "Montrer les références croisées",

--- a/locales/nl/translation.json
+++ b/locales/nl/translation.json
@@ -265,7 +265,7 @@
     "display": "Weergave",
     "text-options": "Tekstopties",
     "bible-browser-layout": "Layout van Bijbelbrowser",
-    "show-tool-bar": "Toon werkbalk",
+    "show-tag-list": "Show tag list",
     "show-book-intro": "Toon inleiding van boek",
     "show-section-titles": "Toon sectietitels",
     "show-xrefs": "Toon kruisverwijzingen",

--- a/locales/ro/translation.json
+++ b/locales/ro/translation.json
@@ -265,7 +265,7 @@
     "display": "Afișare",
     "text-options": "Opțiuni text",
     "bible-browser-layout": "Aspectul navigatorului biblic",
-    "show-tool-bar": "Afișează bară instrumente",
+    "show-tag-list": "Show tag list",
     "show-book-intro": "Afișează introducerea cărții",
     "show-section-titles": "Afișează titlurile secțiunii",
     "show-xrefs": "Afișează referințe încrucișate",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -265,7 +265,7 @@
     "display": "Параметры отображения",
     "text-options": "Параметры текста",
     "bible-browser-layout": "Параметры окна Библии",
-    "show-tool-bar": "Панель инструментов",
+    "show-tag-list": "Show tag list",
     "show-book-intro": "Введения книг",
     "show-section-titles": "Заголовки разделов",
     "show-xrefs": "Перекрестные ссылки",

--- a/locales/sk/translation.json
+++ b/locales/sk/translation.json
@@ -265,7 +265,7 @@
     "display": "Zobraziť",
     "text-options": "Nastavenia textu",
     "bible-browser-layout": "Rozloženie prehľadávača Biblie",
-    "show-tool-bar": "Zobraziť panel s nástrojmi",
+    "show-tag-list": "Show tag list",
     "show-book-intro": "Zobraziť úvod knihy",
     "show-section-titles": "Zobraziť názvy sekcií",
     "show-xrefs": "Zobraziť krížové odkazy",

--- a/locales/uk/translation.json
+++ b/locales/uk/translation.json
@@ -265,7 +265,7 @@
     "display": "Параметри відображення",
     "text-options": "Параметри тексту",
     "bible-browser-layout": "Відобраз переглядача Біблії",
-    "show-tool-bar": "Панель інструментів",
+    "show-tag-list": "Show tag list",
     "show-book-intro": "Передмова до книг",
     "show-section-titles": "Заголовки розділів",
     "show-xrefs": "Перехресні посилання",


### PR DESCRIPTION
The tool bar really only is the tag list. It used to be more (including the dictionary). But since both the tag list and the dictionary can now be shown/hidden individually I suggest to rename "Show tool bar" to "Show tag list".