### PR TITLE
Fix repo update

### DIFF
--- a/app/backend/ipc/ipc_nsi_handler.js
+++ b/app/backend/ipc/ipc_nsi_handler.js
@@ -84,12 +84,8 @@ class IpcNsiHandler {
     });
 
     this._ipcMain.addWithProgressCallback('nsi_updateRepositoryConfig', async (progressCB) => {
-      try {
-        var retCode = await this._nsi.updateRepositoryConfig(progressCB);
-        return retCode;
-      } catch (retCode) {
-        return retCode;
-      }
+        var repoUpdateStatus = await this._nsi.updateRepositoryConfig(progressCB);
+        return repoUpdateStatus;
     }, 'nsi_updateRepoConfigProgress');
     
     this._ipcMain.add('nsi_getRepoNames', () => {

--- a/app/frontend/components/module_assistant/assistant_controller.js
+++ b/app/frontend/components/module_assistant/assistant_controller.js
@@ -179,7 +179,7 @@ module.exports.updateRepositories = async function() {
   var failedUpdateCount = 0;
   const repoUpdateStatus = await ipcNsi.updateRepositoryConfig(process => notifySubscribers('progressUpdate', process));
 
-  for (var key in repoUpdateStatus) {
+  for (let key in repoUpdateStatus) {
     if (key != 'result' && repoUpdateStatus[key] == false) {
       failedUpdateCount += 1;
       console.warn("Repo update failed for " + key);

--- a/app/frontend/ipc/ipc_nsi.js
+++ b/app/frontend/ipc/ipc_nsi.js
@@ -38,11 +38,11 @@ class IpcNsi {
   }
 
   async updateRepositoryConfig(progressCallback=undefined) {
-    var returnValue = await this._ipcRenderer.callWithProgressCallback('nsi_updateRepositoryConfig',
-                                                                       'nsi_updateRepoConfigProgress',
-                                                                       progressCallback,
-                                                                       60000);
-    return returnValue;
+    var repoUpdateStatus = await this._ipcRenderer.callWithProgressCallback('nsi_updateRepositoryConfig',
+                                                                            'nsi_updateRepoConfigProgress',
+                                                                            progressCallback,
+                                                                            60000);
+    return repoUpdateStatus;
   }
 
   async getRepoNames() {

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -53,7 +53,7 @@ class Startup {
 
   async initTest() {
     if (app.commandLine.hasSwitch('install-kjv')) {
-      var repoConfigExisting = await ipcNsi.repositoryConfigExisting();
+      let repoConfigExisting = await ipcNsi.repositoryConfigExisting();
 
       if (!repoConfigExisting) {
         $('#loading-subtitle').text("Updating repository config");
@@ -68,7 +68,7 @@ class Startup {
     }
 
     if (app.commandLine.hasSwitch('install-asv')) {
-      var repoConfigExisting = await ipcNsi.repositoryConfigExisting();
+      let repoConfigExisting = await ipcNsi.repositoryConfigExisting();
 
       if (!repoConfigExisting) {
         $('#loading-subtitle').text("Updating repository config");

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "log-timestamp": "^0.3.0",
     "marked": "^3.0.0",
     "mousetrap": "^1.6.5",
-    "node-sword-interface": "^0.237.0",
+    "node-sword-interface": "^0.238.0",
     "pug": "^3.0.0",
     "remove-markdown": "^0.3.0",
     "sanitize-html": "^2.3.3",


### PR DESCRIPTION
This should fix #395.

@zhuiks
Essentially the repo update is now considered successful even if up to two repositories fail to update.

One thing that we could still do is list out those failed repository updates in the UI in the form of some warning message. Is that something you can add? Depending on when you find time for this you could also put this in a separate issue and then we merge this PR already.

Have a look at my changes in `assistant_controller` / `updateRepositories`.

Note that the test suite would still fail now if an important repository like CrossWire would go down. In that case the installation of the KJV and ASV (test modules) would not work any longer.