### PR TITLE
Brazilian Portuguese update for version 1.4

### DIFF
--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -29,9 +29,9 @@
     "exact-phrase": "Frase exata",
     "multi-word": "Múltiplas palavras",
     "strongs": "Números de Strong",
-    "whole-bible": "Whole Bible",
-    "ot": "Old Testament",
-    "nt": "New Testament",
+    "whole-bible": "Bíblia Completa",
+    "ot": "Velho Testamento",
+    "nt": "Novo Testamento",
     "extended-verse-boundaries": "Limites do versículo estendido (dois versículos)"
   },
   "module-assistant": {
@@ -53,7 +53,7 @@
     "add-modules": "Adicionar {{module_type, accusative}}",
     "remove-modules": "Remover {{module_type, accusative}}",
     "languages": "Idioma",
-    "repository_singular": "Repository",
+    "repository_singular": "Repositório",
     "repository_plural": "Repositórios",
     "installation": "Instalação",
     "removal": "Remoção",
@@ -125,7 +125,7 @@
     "application-version": "Versão do Aplicativo",
     "git-commit": "Git commit",
     "sword-version": "Versão do The SWORD",
-    "sword-path": "SWORD module path",
+    "sword-path": "Caminho do módulo SWORD",
     "chromium-version": "Versão do Chromium",
     "database-path": "Caminho do Banco de Dados",
     "config-file-path": "Caminho da Configuração",
@@ -303,8 +303,8 @@
     "open-complete-book": "Abrir livros completamente",
     "open-chapters-large-books": "Abrir grandes livros em modo capítulo-inteligente",
     "open-chapters-all-books": "Abrir todos os livros em modo capítulo-inteligente",
-    "copy": "Copy",
-    "edit-note": "Edit note"
+    "copy": "Copiar",
+    "edit-note": "Editar nota"
   },
   "dictionary-panel": {
     "greek-dict": "Dicionário de Grego",


### PR DESCRIPTION
All the vars below are updated!

"whole-bible": "Whole Bible"
"ot": "Old Testament"
"nt": "New Testament"
"repository_singular": "Repository"
"copy": "Copy"
"edit-note": "Edit note"
"sword-path": "SWORD module path"