### PR TITLE
Localize application menu on macOS

### DIFF
--- a/app/frontend/controllers/i18n_controller.js
+++ b/app/frontend/controllers/i18n_controller.js
@@ -169,6 +169,17 @@ module.exports.changeLocale = async function(newLocale, saveSettings=true) {
   $(document).localize();
   window.reference_separator = i18n.t('general.chapter-verse-separator');
   await eventController.publishAsync('on-locale-changed', newLocale);
+
+  if (this._platformHelper.isMac()) {
+    const { ipcRenderer } = require('electron');
+
+    let menuLabels = {
+      'file': i18n.t('application-menu.file'),
+      'quit-app': i18n.t('application-menu.quit-app')
+    };
+
+    ipcRenderer.invoke('localizeMenu', menuLabels);
+  }
 };
 
 module.exports.detectLocale = async function() {

--- a/app/frontend/controllers/i18n_controller.js
+++ b/app/frontend/controllers/i18n_controller.js
@@ -137,6 +137,10 @@ module.exports.initLocale = async function() {
   }
 
   window.reference_separator = i18n.t('general.chapter-verse-separator');
+
+  if (platformHelper.isMac()) {
+    await this.localizeMenu();
+  }
 };
 
 function preserveStringsForStartup() {
@@ -170,16 +174,20 @@ module.exports.changeLocale = async function(newLocale, saveSettings=true) {
   window.reference_separator = i18n.t('general.chapter-verse-separator');
   await eventController.publishAsync('on-locale-changed', newLocale);
 
-  if (this._platformHelper.isMac()) {
-    const { ipcRenderer } = require('electron');
-
-    let menuLabels = {
-      'file': i18n.t('application-menu.file'),
-      'quit-app': i18n.t('application-menu.quit-app')
-    };
-
-    ipcRenderer.invoke('localizeMenu', menuLabels);
+  if (platformHelper.isMac()) {
+    await this.localizeMenu();
   }
+};
+
+module.exports.localizeMenu = async function() {
+  const { ipcRenderer } = require('electron');
+
+  let menuLabels = {
+    'file': i18n.t('application-menu.file'),
+    'quit-app': i18n.t('application-menu.quit-app')
+  };
+
+  await ipcRenderer.invoke('localizeMenu', menuLabels);
 };
 
 module.exports.detectLocale = async function() {

--- a/app/frontend/controllers/i18n_controller.js
+++ b/app/frontend/controllers/i18n_controller.js
@@ -183,7 +183,6 @@ module.exports.localizeMenu = async function() {
   const { ipcRenderer } = require('electron');
 
   let menuLabels = {
-    'file': i18n.t('application-menu.file'),
     'quit-app': i18n.t('application-menu.quit-app')
   };
 

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -10,7 +10,6 @@
     "context": "Kontext"
   },
   "application-menu": {
-    "file": "&Datei",
     "quit-app": "Ezra Bible App beenden"
   },
   "menu": {

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -9,6 +9,10 @@
     "compare": "Vergleichen",
     "context": "Kontext"
   },
+  "application-menu": {
+    "file": "&Datei",
+    "quit-app": "Ezra Bible App beenden"
+  },
   "menu": {
     "book": "Buch",
     "tags": "Tags",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -10,7 +10,6 @@
     "context": "Context"
   },
   "application-menu": {
-    "file": "&File",
     "quit-app": "Quit Ezra Bible App"
   },
   "menu": {

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -9,6 +9,10 @@
     "compare": "Compare",
     "context": "Context"
   },
+  "application-menu": {
+    "file": "&File",
+    "quit-app": "Quit Ezra Bible App"
+  },
   "menu": {
     "book": "Book",
     "tags": "Tags",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -9,6 +9,9 @@
     "compare": "Comparar",
     "context": "Contexto"
   },
+  "application-menu": {
+    "quit-app": "Quit Ezra Bible App"
+  },
   "menu": {
     "book": "Libro",
     "tags": "Etiquetas",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -9,6 +9,9 @@
     "compare": "Comparer",
     "context": "Contexte"
   },
+  "application-menu": {
+    "quit-app": "Quit Ezra Bible App"
+  },
   "menu": {
     "book": "Livre",
     "tags": "Étiquettes",

--- a/locales/nl/translation.json
+++ b/locales/nl/translation.json
@@ -9,6 +9,9 @@
     "compare": "Vergelijken",
     "context": "Context"
   },
+  "application-menu": {
+    "quit-app": "Quit Ezra Bible App"
+  },
   "menu": {
     "book": "Boek",
     "tags": "Tags",

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -9,6 +9,9 @@
     "compare": "Comparar",
     "context": "Contexto"
   },
+  "application-menu": {
+    "quit-app": "Quit Ezra Bible App"
+  },
   "menu": {
     "book": "Livro",
     "tags": "Etiquetas",

--- a/locales/ro/translation.json
+++ b/locales/ro/translation.json
@@ -9,6 +9,9 @@
     "compare": "Compară",
     "context": "Context"
   },
+  "application-menu": {
+    "quit-app": "Quit Ezra Bible App"
+  },
   "menu": {
     "book": "Carte",
     "tags": "Etichete",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -9,6 +9,9 @@
     "compare": "Сравнить",
     "context": "Контекст"
   },
+  "application-menu": {
+    "quit-app": "Quit Ezra Bible App"
+  },
   "menu": {
     "book": "Книга",
     "tags": "Метки",

--- a/locales/sk/translation.json
+++ b/locales/sk/translation.json
@@ -9,6 +9,9 @@
     "compare": "Porovnať",
     "context": "Kontext"
   },
+  "application-menu": {
+    "quit-app": "Quit Ezra Bible App"
+  },
   "menu": {
     "book": "Kniha",
     "tags": "Značky",

--- a/locales/uk/translation.json
+++ b/locales/uk/translation.json
@@ -9,6 +9,9 @@
     "compare": "Порівняти",
     "context": "Контекст"
   },
+  "application-menu": {
+    "quit-app": "Quit Ezra Bible App"
+  },
   "menu": {
     "book": "Книга",
     "tags": "Міти",

--- a/main.js
+++ b/main.js
@@ -82,6 +82,27 @@ function shouldUseDarkMode() {
   return useDarkMode;
 }
 
+function updateMenu(labels=undefined) {
+  var fileLabel = '&File';
+  var quitAppLabel = 'Quit Ezra Bible App';
+
+  if (labels !== undefined) {
+    fileLabel = labels['file'];
+    quitAppLabel = labels['quit-app'];
+  }
+
+  const menu = Menu.buildFromTemplate([{
+    label: fileLabel,
+    submenu: [{
+      label: quitAppLabel,
+      accelerator: 'Ctrl+Q',
+      click: function () { app.quit(); }
+    }]
+  }]);
+
+  Menu.setApplicationMenu(menu);
+}
+
 async function createWindow () {
   const path = require('path');
   const url = require('url');
@@ -126,6 +147,11 @@ async function createWindow () {
     ipcMain.handle('startupCompleted', async (event, arg) => {
       console.timeEnd('Startup');
     });
+
+    // eslint-disable-next-line no-unused-vars
+    ipcMain.on('localizeMenu', async (event, menuLabels) => {
+      updateMenu(menuLabels);
+    });
   }
 
   var bgColor = '#ffffff';
@@ -160,16 +186,7 @@ async function createWindow () {
   Menu.setApplicationMenu(null);
 
   if (platformHelper.isMac()) {
-    const menu = Menu.buildFromTemplate([{
-      label: '&File',
-      submenu: [{
-        label: 'Quit Ezra Bible App',
-        accelerator: 'Ctrl+Q',
-        click: function () { app.quit(); }
-      }]
-    }]);
-
-    Menu.setApplicationMenu(menu);
+    updateMenu();
   }
 
   // and load the index.html of the app.

--- a/main.js
+++ b/main.js
@@ -149,7 +149,7 @@ async function createWindow () {
     });
 
     // eslint-disable-next-line no-unused-vars
-    ipcMain.on('localizeMenu', async (event, menuLabels) => {
+    ipcMain.handle('localizeMenu', async (event, menuLabels) => {
       updateMenu(menuLabels);
     });
   }

--- a/main.js
+++ b/main.js
@@ -83,16 +83,14 @@ function shouldUseDarkMode() {
 }
 
 function updateMenu(labels=undefined) {
-  var fileLabel = '&File';
   var quitAppLabel = 'Quit Ezra Bible App';
 
   if (labels !== undefined) {
-    fileLabel = labels['file'];
     quitAppLabel = labels['quit-app'];
   }
 
   const menu = Menu.buildFromTemplate([{
-    label: fileLabel,
+    label: '&File',
     submenu: [{
       label: quitAppLabel,
       accelerator: 'Ctrl+Q',


### PR DESCRIPTION
With some extra IPC calls from frontend to backend it was rather easy to add an actual localization of the application menu.

You can give this a try with German (already localized) or add another locale's translation in this new section (already available in all locale files):

```JavaScript
  "application-menu": {
    "quit-app": "Quit Ezra Bible App"
  }
```

This closes #353.