### PR TITLE
Change Dropbox configuration to use app folder instead of custom folder

### DIFF
--- a/app/backend/ipc/ipc_db_handler.js
+++ b/app/backend/ipc/ipc_db_handler.js
@@ -99,11 +99,10 @@ class IpcDbHandler {
 
     console.log('Synchronizing database with Dropbox!');
 
-    const DROPBOX_CLIENT_ID = 'omhgjqlxpfn2r8z';
-    const dropboxFolder = this._config.get('dropboxFolder', 'ezra');
+    const DROPBOX_CLIENT_ID = '6m7e5ri5udcbkp3';
     const firstDropboxSyncDone = this._config.get('firstDropboxSyncDone', false);
     const databaseFilePath = this.getDatabaseFilePath();
-    const dropboxFilePath = `/${dropboxFolder}/ezra.sqlite`;
+    const dropboxFilePath = `/ezra.sqlite`;
 
     let prioritizeRemote = false;
     if (!firstDropboxSyncDone) {

--- a/app/backend/ipc/ipc_db_handler.js
+++ b/app/backend/ipc/ipc_db_handler.js
@@ -33,6 +33,7 @@ class IpcDbHandler {
     this._config = ipc.ipcSettingsHandler.getConfig();
     this._dropboxSyncTimeout = null;
     this._dropboxSyncInProgress = false;
+    this._dropboxAccessUpgradeNeeded = false;
 
     this.initIpcInterface();
   }
@@ -78,6 +79,7 @@ class IpcDbHandler {
           console.log('WARNING: Resetting dropbox configuration, since this version of Ezra Bible App uses a new way to connect with Dropbox!');
           this.resetDropboxConfig();
           dropboxConfigValid = false;
+          this._dropboxAccessUpgradeNeeded = true;
         }
       }
       
@@ -256,6 +258,10 @@ class IpcDbHandler {
       if (this.hasValidDropboxConfig()) {
         await this.syncDatabaseWithDropbox(connectionType);
       }
+    });
+
+    this._ipcMain.add('db_isDropboxAccessUpgradeNeeded', async() => {
+      return this._dropboxAccessUpgradeNeeded;
     });
 
     this._ipcMain.add('db_getDatabasePath', async() => {

--- a/app/backend/ipc/ipc_db_handler.js
+++ b/app/backend/ipc/ipc_db_handler.js
@@ -75,7 +75,7 @@ class IpcDbHandler {
         let lastMinorVersion = parseInt(lastUsedVersion[1]);
 
         if (lastMajorVersion == 1 && lastMinorVersion < 15) {
-          console.log('Resetting dropbox configuration, since this version of Ezra Bible App uses a new way to connect with Dropbox.');
+          console.log('WARNING: Resetting dropbox configuration, since this version of Ezra Bible App uses a new way to connect with Dropbox!');
           this.resetDropboxConfig();
           dropboxConfigValid = false;
         }

--- a/app/backend/ipc/ipc_db_handler.js
+++ b/app/backend/ipc/ipc_db_handler.js
@@ -93,13 +93,13 @@ class IpcDbHandler {
   }
 
   resetDropboxConfig() {
-    this._config.set('lastDropboxSyncResult', null);
-    this._config.set('lastDropboxSyncTime', null);
-    this._config.set('lastDropboxDownloadTime', null);
-    this._config.set('lastDropboxUploadTime', null);
+    this._config.set('lastDropboxSyncResult', '');
+    this._config.set('lastDropboxSyncTime', '');
+    this._config.set('lastDropboxDownloadTime', '');
+    this._config.set('lastDropboxUploadTime', '');
     this._config.set('firstDropboxSyncDone', false);
-    this._config.set('dropboxToken', null);
-    this._config.set('dropboxRefreshToken', null);
+    this._config.set('dropboxToken', '');
+    this._config.set('dropboxRefreshToken', '');
     this._config.set('dropboxLinkStatus', null);
   }
 

--- a/app/frontend/components/info_popup.js
+++ b/app/frontend/components/info_popup.js
@@ -131,7 +131,7 @@ class InfoPopup {
     if (await ipcSettings.has('lastDropboxDownloadTime')) {
       let rawDropboxDownloadTime = await ipcSettings.get('lastDropboxDownloadTime', '--');
 
-      if (rawDropboxDownloadTime != '--' && rawDropboxDownloadTime != '') {
+      if (rawDropboxDownloadTime != '--' && rawDropboxDownloadTime != '' && rawDropboxDownloadTime != null) {
         lastDropboxDownloadTime = new Date(rawDropboxDownloadTime);
         lastDropboxDownloadTime = this.getFormattedTimestamp(lastDropboxDownloadTime);
       }
@@ -141,13 +141,16 @@ class InfoPopup {
     if (await ipcSettings.has('lastDropboxUploadTime')) {
       let rawDropboxUploadTime = await ipcSettings.get('lastDropboxUploadTime', '--');
 
-      if (rawDropboxUploadTime != '--' && rawDropboxUploadTime != '') {
+      if (rawDropboxUploadTime != '--' && rawDropboxUploadTime != '' && rawDropboxUploadTime != null) {
         lastDropboxUploadTime = new Date(rawDropboxUploadTime);
         lastDropboxUploadTime = this.getFormattedTimestamp(lastDropboxUploadTime);
       }
     }
 
-    const lastDropboxSyncResult = await ipcSettings.get('lastDropboxSyncResult', '--');
+    let lastDropboxSyncResult = await ipcSettings.get('lastDropboxSyncResult', '--');
+    if (lastDropboxSyncResult == null) {
+      lastDropboxSyncResult = '--'
+    }
 
     const moduleDescription = await swordModuleHelper.getModuleDescription(currentModuleId);
     const moduleInfo = await swordModuleHelper.getModuleInfo(currentModuleId, false, false);

--- a/app/frontend/components/tags/tag_group_list.js
+++ b/app/frontend/components/tags/tag_group_list.js
@@ -16,7 +16,7 @@
    along with Ezra Bible App. See the file LICENSE.
    If not, see <http://www.gnu.org/licenses/>. */
 
-const { html, showErrorDialog } = require('../../helpers/ezra_helper.js');
+const { html, showDialog } = require('../../helpers/ezra_helper.js');
 const eventController = require('../../controllers/event_controller.js');
 const TagGroupManager = require('./tag_group_manager.js');
 const tagGroupValidator = require('./tag_group_validator.js');
@@ -350,7 +350,7 @@ class TagGroupList extends HTMLElement {
                      ${result.exception}<br><br>
                      Please restart the app.`;
 
-      await showErrorDialog('Database Error', message);
+      await showDialog('Database Error', message);
       return null;
     }
 
@@ -462,7 +462,7 @@ class TagGroupList extends HTMLElement {
                      ${result.exception}<br><br>
                      Please restart the app.`;
 
-      await showErrorDialog('Database Error', message);
+      await showDialog('Database Error', message);
       return;
     } else {
       await eventController.publishAsync('on-tag-group-renamed', tagGroupId);
@@ -529,7 +529,7 @@ class TagGroupList extends HTMLElement {
                      ${result.exception}<br><br>
                      Please restart the app.`;
 
-      await showErrorDialog('Database Error', message);
+      await showDialog('Database Error', message);
       return;
     } else {
       await eventController.publishAsync('on-tag-group-deleted', tagGroupId);

--- a/app/frontend/controllers/db_sync_controller.js
+++ b/app/frontend/controllers/db_sync_controller.js
@@ -29,7 +29,7 @@ const PlatformHelper = require('../../lib/platform_helper.js');
 const platformHelper = new PlatformHelper();
 const eventController = require('./event_controller.js');
 
-const DROPBOX_CLIENT_ID = 'omhgjqlxpfn2r8z';
+const DROPBOX_CLIENT_ID = '6m7e5ri5udcbkp3';
 const DROPBOX_TOKEN_SETTINGS_KEY = 'dropboxToken';
 const DROPBOX_REFRESH_TOKEN_SETTINGS_KEY = 'dropboxRefreshToken';
 const DROPBOX_LINK_STATUS_SETTINGS_KEY = 'dropboxLinkStatus';

--- a/app/frontend/controllers/db_sync_controller.js
+++ b/app/frontend/controllers/db_sync_controller.js
@@ -33,7 +33,6 @@ const DROPBOX_CLIENT_ID = '6m7e5ri5udcbkp3';
 const DROPBOX_TOKEN_SETTINGS_KEY = 'dropboxToken';
 const DROPBOX_REFRESH_TOKEN_SETTINGS_KEY = 'dropboxRefreshToken';
 const DROPBOX_LINK_STATUS_SETTINGS_KEY = 'dropboxLinkStatus';
-const DROPBOX_FOLDER_SETTINGS_KEY = 'dropboxFolder';
 const DROPBOX_ONLY_WIFI_SETTINGS_KEY = 'dropboxOnlyWifi';
 const DROPBOX_SYNC_AFTER_CHANGES_KEY = 'dropboxSyncAfterChanges';
 const DROPBOX_LAST_SYNC_RESULT_KEY = 'lastDropboxSyncResult';
@@ -46,7 +45,6 @@ let dbSyncInitDone = false;
 let dbSyncDropboxToken = null;
 let dbSyncDropboxRefreshToken = null;
 let dbSyncDropboxLinkStatus = null;
-let dbSyncDropboxFolder = null;
 let dbSyncOnlyWifi = false;
 let dbSyncAfterChanges = false;
 let dbSyncFirstSyncDone = false;
@@ -169,12 +167,10 @@ async function initDbSync() {
   dbSyncDropboxToken = await ipcSettings.get(DROPBOX_TOKEN_SETTINGS_KEY, "");
   dbSyncDropboxRefreshToken = await ipcSettings.get(DROPBOX_REFRESH_TOKEN_SETTINGS_KEY, "");
   dbSyncDropboxLinkStatus = await ipcSettings.get(DROPBOX_LINK_STATUS_SETTINGS_KEY, null);
-  dbSyncDropboxFolder = await ipcSettings.get(DROPBOX_FOLDER_SETTINGS_KEY, 'ezra');
   dbSyncOnlyWifi = await ipcSettings.get(DROPBOX_ONLY_WIFI_SETTINGS_KEY, false);
   dbSyncAfterChanges = await ipcSettings.get(DROPBOX_SYNC_AFTER_CHANGES_KEY, false);
   dbSyncFirstSyncDone = await ipcSettings.get(DROPBOX_FIRST_SYNC_DONE_KEY, false);
 
-  $('#dropbox-sync-folder').val(dbSyncDropboxFolder);
   document.getElementById('only-sync-on-wifi').checked = dbSyncOnlyWifi;
   document.getElementById('sync-dropbox-after-changes').checked = dbSyncAfterChanges;
   updateDropboxLinkStatusLabel();
@@ -231,7 +227,6 @@ async function initDbSync() {
 async function handleDropboxConfigurationSave() {
   $('#db-sync-box').dialog("close");
 
-  dbSyncDropboxFolder = $('#dropbox-sync-folder').val();
   dbSyncOnlyWifi = document.getElementById('only-sync-on-wifi').checked;
   dbSyncAfterChanges = document.getElementById('sync-dropbox-after-changes').checked;
 
@@ -254,7 +249,6 @@ async function handleDropboxConfigurationSave() {
   }
 
   await ipcSettings.set(DROPBOX_LINK_STATUS_SETTINGS_KEY, dbSyncDropboxLinkStatus);
-  await ipcSettings.set(DROPBOX_FOLDER_SETTINGS_KEY, dbSyncDropboxFolder);
   await ipcSettings.set(DROPBOX_ONLY_WIFI_SETTINGS_KEY, dbSyncOnlyWifi);
   await ipcSettings.set(DROPBOX_SYNC_AFTER_CHANGES_KEY, dbSyncAfterChanges);
 

--- a/app/frontend/controllers/notes_controller.js
+++ b/app/frontend/controllers/notes_controller.js
@@ -24,7 +24,7 @@ const i18nHelper = require('../helpers/i18n_helper.js');
 const eventController = require('../controllers/event_controller.js');
 const verseListController = require('../controllers/verse_list_controller.js');
 const PlatformHelper = require('../../lib/platform_helper.js');
-const { showErrorDialog, sleep } = require('../helpers/ezra_helper.js');
+const { showDialog, sleep } = require('../helpers/ezra_helper.js');
 require('../components/emoji_button_trigger.js');
 
 let CodeMirror = null;
@@ -319,7 +319,7 @@ class NotesController {
                         ${result.exception}<br><br>
                         Please restart the app.`;
 
-          await showErrorDialog('Database Error', message);
+          await showDialog('Database Error', message);
           this._focusEditor();
           return false;
         }

--- a/app/frontend/controllers/tags_controller.js
+++ b/app/frontend/controllers/tags_controller.js
@@ -24,7 +24,7 @@ require('../components/emoji_button_trigger.js');
 const { waitUntilIdle } = require('../helpers/ezra_helper.js');
 const eventController = require('./event_controller.js');
 const verseListController = require('../controllers/verse_list_controller.js');
-const { showErrorDialog } = require('../helpers/ezra_helper.js');
+const { showDialog } = require('../helpers/ezra_helper.js');
 
 /**
  * The TagsController handles most functionality related to tagging of verses.
@@ -393,7 +393,7 @@ class TagsController {
                       ${result.exception}<br><br>
                       Please restart the app.`;
 
-        await showErrorDialog('Database Error', message);
+        await showDialog('Database Error', message);
         uiHelper.hideTextLoadingIndicator();
         return;
       } else {
@@ -582,7 +582,7 @@ class TagsController {
                      ${result.exception}<br><br>
                      Please restart the app.`;
 
-      await showErrorDialog('Database Error', message);
+      await showDialog('Database Error', message);
       uiHelper.hideTextLoadingIndicator();
       return;
     }
@@ -661,7 +661,7 @@ class TagsController {
                      ${result.exception}<br><br>
                      Please restart the app.`;
 
-      await showErrorDialog('Database Error', message);
+      await showDialog('Database Error', message);
       uiHelper.hideTextLoadingIndicator();
       return;
     }
@@ -824,7 +824,7 @@ class TagsController {
                       ${result.exception}<br><br>
                       Please restart the app.`;
 
-        await showErrorDialog('Database Error', message);
+        await showDialog('Database Error', message);
         uiHelper.hideTextLoadingIndicator();
         return;
       }
@@ -1003,7 +1003,7 @@ class TagsController {
                       ${result.exception}<br><br>
                       Please restart the app.`;
 
-        await showErrorDialog('Database Error', message);
+        await showDialog('Database Error', message);
         uiHelper.hideTextLoadingIndicator();
         return;
       }
@@ -1142,7 +1142,7 @@ class TagsController {
                     ${result.exception}<br><br>
                     Please restart the app.`;
 
-      await showErrorDialog('Database Error', message);
+      await showDialog('Database Error', message);
       uiHelper.hideTextLoadingIndicator();
       return;
     }

--- a/app/frontend/helpers/ezra_helper.js
+++ b/app/frontend/helpers/ezra_helper.js
@@ -99,17 +99,17 @@ module.exports.removeItemFromArray = function(arr, value) {
 };
 
 /**
- * This function shows a modal error dialog to the user.
+ * This function shows a modal dialog to the user.
  *  
  * @param {string} dialogTitle The title of the dialog
- * @param {string} errorMessage The message that shall be displayed
+ * @param {string} message The message that shall be displayed
  * @returns {Promise} A promise that resolves when the user confirms/closes the dialog
  */
-module.exports.showErrorDialog = async function(dialogTitle, errorMessage) {
+module.exports.showDialog = async function(dialogTitle, message) {
   const dialogBoxTemplate = module.exports.html`
-  <div id="error-dialog">
-    <div id="error-dialog-content" style="padding-top: 2em;">
-    ${errorMessage}
+  <div id="info-dialog">
+    <div id="info-dialog-content" style="padding-top: 2em;">
+    ${message}
     </div>
   </div>
   `;
@@ -117,7 +117,7 @@ module.exports.showErrorDialog = async function(dialogTitle, errorMessage) {
   return new Promise((resolve) => {
 
     document.querySelector('#boxes').appendChild(dialogBoxTemplate.content);
-    const $dialogBox = $('#error-dialog');
+    const $dialogBox = $('#info-dialog');
     
     var confirmed = false;
     const width = 500;
@@ -125,7 +125,7 @@ module.exports.showErrorDialog = async function(dialogTitle, errorMessage) {
     const offsetLeft = ($(window).width() - width)/2;
 
     let dialogOptions = uiHelper.getDialogOptions(width, height, false, [offsetLeft, 120]);
-    dialogOptions.dialogClass = 'ezra-dialog error-dialog';
+    dialogOptions.dialogClass = 'ezra-dialog info-dialog';
     dialogOptions.title = dialogTitle;
     dialogOptions.buttons = {};
     dialogOptions.close = () => {
@@ -140,6 +140,6 @@ module.exports.showErrorDialog = async function(dialogTitle, errorMessage) {
     };
   
     $dialogBox.dialog(dialogOptions);
-    uiHelper.fixDialogCloseIconOnAndroid('error-dialog');
+    uiHelper.fixDialogCloseIconOnAndroid('info-dialog');
   });
 };

--- a/app/frontend/helpers/ezra_helper.js
+++ b/app/frontend/helpers/ezra_helper.js
@@ -105,7 +105,7 @@ module.exports.removeItemFromArray = function(arr, value) {
  * @param {string} message The message that shall be displayed
  * @returns {Promise} A promise that resolves when the user confirms/closes the dialog
  */
-module.exports.showDialog = async function(dialogTitle, message) {
+module.exports.showDialog = async function(dialogTitle, message, width=500, height=300) {
   const dialogBoxTemplate = module.exports.html`
   <div id="info-dialog">
     <div id="info-dialog-content" style="padding-top: 2em;">
@@ -120,8 +120,6 @@ module.exports.showDialog = async function(dialogTitle, message) {
     const $dialogBox = $('#info-dialog');
     
     var confirmed = false;
-    const width = 500;
-    const height = 300;
     const offsetLeft = ($(window).width() - width)/2;
 
     let dialogOptions = window.uiHelper.getDialogOptions(width, height, false, [offsetLeft, 120]);

--- a/app/frontend/helpers/ezra_helper.js
+++ b/app/frontend/helpers/ezra_helper.js
@@ -126,6 +126,7 @@ module.exports.showDialog = async function(dialogTitle, message, width=500, heig
     dialogOptions.dialogClass = 'ezra-dialog info-dialog';
     dialogOptions.title = dialogTitle;
     dialogOptions.buttons = {};
+    dialogOptions.modal = true;
     dialogOptions.close = () => {
       $dialogBox.dialog('destroy');
       $dialogBox.remove();

--- a/app/frontend/helpers/ezra_helper.js
+++ b/app/frontend/helpers/ezra_helper.js
@@ -139,6 +139,6 @@ module.exports.showDialog = async function(dialogTitle, message, width=500, heig
     };
   
     $dialogBox.dialog(dialogOptions);
-    uiHelper.fixDialogCloseIconOnAndroid('info-dialog');
+    window.uiHelper.fixDialogCloseIconOnAndroid('info-dialog');
   });
 };

--- a/app/frontend/helpers/ezra_helper.js
+++ b/app/frontend/helpers/ezra_helper.js
@@ -124,7 +124,7 @@ module.exports.showDialog = async function(dialogTitle, message) {
     const height = 300;
     const offsetLeft = ($(window).width() - width)/2;
 
-    let dialogOptions = uiHelper.getDialogOptions(width, height, false, [offsetLeft, 120]);
+    let dialogOptions = window.uiHelper.getDialogOptions(width, height, false, [offsetLeft, 120]);
     dialogOptions.dialogClass = 'ezra-dialog info-dialog';
     dialogOptions.title = dialogTitle;
     dialogOptions.buttons = {};

--- a/app/frontend/ipc/ipc_db.js
+++ b/app/frontend/ipc/ipc_db.js
@@ -48,6 +48,10 @@ class IpcDb {
     return await this._ipcRenderer.call('db_syncDropbox', connectionType);
   }
 
+  async dropboxAccessUpgradeNeeded() {
+    return await this._ipcRenderer.call('db_isDropboxAccessUpgradeNeeded');
+  }
+
   async getDatabasePath() {
     return await this._ipcRenderer.call('db_getDatabasePath');
   }

--- a/app/frontend/ipc/ipc_db.js
+++ b/app/frontend/ipc/ipc_db.js
@@ -48,7 +48,7 @@ class IpcDb {
     return await this._ipcRenderer.call('db_syncDropbox', connectionType);
   }
 
-  async dropboxAccessUpgradeNeeded() {
+  async isDropboxAccessUpgradeNeeded() {
     return await this._ipcRenderer.call('db_isDropboxAccessUpgradeNeeded');
   }
 

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -493,14 +493,14 @@ class Startup {
 
       const message = 'The Dropbox access method has changed!<br/><br/>' +
                       'Previously a custom folder was used for Dropbox access.<br/>From Ezra Bible App 1.15, app folder access is used.<br/><br/>' +
-                      'The link of Ezra Bible App to your Dropbox account has been reset (No need to worry about data loss!).<br/>' +
+                      'The link of Ezra Bible App to your Dropbox account has been reset.<br/>' +
                       'These are the actions you need to take now:' +
                       '<ul>' +
                       '<li>Please re-configure the Dropbox account link.</li>' +
                       '<li>You need to upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same.</li>' +
                       '</ul>';
 
-      await showDialog('Change of Dropbox access method', message, 600, 500);
+      await showDialog('Change of Dropbox access method', message, 600, 450);
     }
 
     await eventController.publishAsync('on-startup-completed');

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -492,12 +492,11 @@ class Startup {
       // Here we inform the user about this change.
 
       const message = 'The Dropbox access method has changed.<br/><br/>' +
-                      'Previously a custom folder was used for Dropbox access.<br/>Now we are using app folder access.<br/><br/>' +
-                      'The link to your dropbox account has been reset.<br/>Please re-configure the Dropbox account link.'
+                      'Previously a custom folder was used for Dropbox access.<br/>From version 1.15 app folder access is used.<br/><br/>' +
+                      'The link to your Dropbox account has been reset.<br/>Please re-configure the Dropbox account link.<br/><br/>' +
+                      'You need to upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same.';
 
-      await showDialog('Change of Dropbox Configuration', message);
-    } else {
-      console.log('Dropbox upgrade is not needed ...');
+      await showDialog('Change of Dropbox access method', message);
     }
 
     await eventController.publishAsync('on-startup-completed');

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -491,11 +491,13 @@ class Startup {
       // The Dropbox access level has changed from full access to app folder access in version 1.15.
       // Here we inform the user about this change.
 
-      const message = 'The Dropbox access method has changed.<br/><br/>' +
+      const message = 'The Dropbox access method has changed!<br/><br/>' +
                       'Previously a custom folder was used for Dropbox access.<br/>From Ezra Bible App 1.15, app folder access is used.<br/><br/>' +
-                      'The link of Ezra Bible App to your Dropbox account has been reset (No need to worry about data loss!)<br/>' +
-                      'Please re-configure the Dropbox account link.<br/><br/>' +
-                      'You need to upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same.';
+                      'The link of Ezra Bible App to your Dropbox account has been reset (No need to worry about data loss!)<br/><br/>' +
+                      '<ul>'
+                      '<li>Please re-configure the Dropbox account link.</li>' +
+                      '<li>You need to upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same.</li>' +
+                      '</ul>';
 
       await showDialog('Change of Dropbox access method', message, 600, 400);
     }

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -493,13 +493,14 @@ class Startup {
 
       const message = 'The Dropbox access method has changed!<br/><br/>' +
                       'Previously a custom folder was used for Dropbox access.<br/>From Ezra Bible App 1.15, app folder access is used.<br/><br/>' +
-                      'The link of Ezra Bible App to your Dropbox account has been reset (No need to worry about data loss!)<br/><br/>' +
+                      'The link of Ezra Bible App to your Dropbox account has been reset (No need to worry about data loss!).<br/>' +
+                      'These are the actions you need to take now:' +
                       '<ul>' +
                       '<li>Please re-configure the Dropbox account link.</li>' +
                       '<li>You need to upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same.</li>' +
                       '</ul>';
 
-      await showDialog('Change of Dropbox access method', message, 600, 400);
+      await showDialog('Change of Dropbox access method', message, 600, 500);
     }
 
     await eventController.publishAsync('on-startup-completed');

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -496,6 +496,8 @@ class Startup {
                       'The link to your dropbox account has been reset.<br/>Please re-configure the Dropbox account link.'
 
       await showDialog('Change of Dropbox Configuration', message);
+    } else {
+      console.log('Dropbox upgrade is not needed ...');
     }
 
     await eventController.publishAsync('on-startup-completed');

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -492,11 +492,11 @@ class Startup {
       // Here we inform the user about this change.
 
       const message = 'The Dropbox access method has changed.<br/><br/>' +
-                      'Previously a custom folder was used for Dropbox access.<br/>From version 1.15 app folder access is used.<br/><br/>' +
+                      'Previously a custom folder was used for Dropbox access.<br/>From Ezra Bible App 1.15, app folder access is used.<br/><br/>' +
                       'The link to your Dropbox account has been reset.<br/>Please re-configure the Dropbox account link.<br/><br/>' +
                       'You need to upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same.';
 
-      await showDialog('Change of Dropbox access method', message);
+      await showDialog('Change of Dropbox access method', message, 600, 400);
     }
 
     await eventController.publishAsync('on-startup-completed');

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -491,15 +491,13 @@ class Startup {
       // The Dropbox access level has changed from full access to app folder access in version 1.15.
       // Here we inform the user about this change.
 
-      const message = ```
-      ${i18n.t('dropbox.access-method-message-part1')}
-      ${i18n.t('dropbox.access-method-message-part2')}
-      ${i18n.t('dropbox.access-method-message-part3')}
-      <ul>
-        <li>${i18n.t('dropbox.access-method-message-part4')}</li>
-        <li>${i18n.t('dropbox.access-method-message-part5')}</li>
-      </ul>
-      ```;
+      const message = i18n.t('dropbox.access-method-message-part1') +
+                      i18n.t('dropbox.access-method-message-part2') +
+                      i18n.t('dropbox.access-method-message-part3') +
+                      `<ul>
+                        <li>${i18n.t('dropbox.access-method-message-part4')}</li>
+                        <li>${i18n.t('dropbox.access-method-message-part5')}</li>
+                      </ul>`;
 
       await showDialog(i18n.t('dropbox.access-method-change'), message, 600, 450);
     }

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -494,7 +494,7 @@ class Startup {
       const message = 'The Dropbox access method has changed!<br/><br/>' +
                       'Previously a custom folder was used for Dropbox access.<br/>From Ezra Bible App 1.15, app folder access is used.<br/><br/>' +
                       'The link of Ezra Bible App to your Dropbox account has been reset (No need to worry about data loss!)<br/><br/>' +
-                      '<ul>'
+                      '<ul>' +
                       '<li>Please re-configure the Dropbox account link.</li>' +
                       '<li>You need to upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same.</li>' +
                       '</ul>';

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -495,9 +495,10 @@ class Startup {
                       i18n.t('dropbox.access-method-message-part2') +
                       i18n.t('dropbox.access-method-message-part3') +
                       i18n.t('dropbox.access-method-message-part4') +
+                      i18n.t('dropbox.access-method-message-part5') +
                       `<ul>
-                        <li>${i18n.t('dropbox.access-method-message-part5')}</li>
                         <li>${i18n.t('dropbox.access-method-message-part6')}</li>
+                        <li>${i18n.t('dropbox.access-method-message-part7')}</li>
                       </ul>`;
 
       await showDialog(i18n.t('dropbox.access-method-change'), message, 600, 450);

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -452,8 +452,6 @@ class Startup {
 
     console.timeEnd("application-startup");
 
-    let lastUsedVersion = await ipcSettings.get('lastUsedVersion');
-
     // Save some meta data about versions used
     cacheController.saveLastUsedVersion();
 
@@ -487,21 +485,17 @@ class Startup {
       newReleaseChecker.check();
     }
 
-    if (lastUsedVersion != '') {
-      lastUsedVersion = lastUsedVersion.split('.');
-      let lastMajorVersion = parseInt(lastUsedVersion[0]);
-      let lastMinorVersion = parseInt(lastUsedVersion[1]);
+    const isDropboxAccessUpgradeNeeded = await ipcDb.isDropboxAccessUpgradeNeeded();
 
-      if (lastMajorVersion == 1 && lastMinorVersion < 15) {
-        // The Dropbox access level has changed from full access to app folder access in version 1.15.
-        // Here we inform the user about this change.
+    if (isDropboxAccessUpgradeNeeded) {
+      // The Dropbox access level has changed from full access to app folder access in version 1.15.
+      // Here we inform the user about this change.
 
-        const message = 'The Dropbox access method has changed.<br/><br/>' +
-                        'Previously a custom folder was used for Dropbox access.<br/>Now we are using app folder access.<br/><br/>' +
-                        'The link to your dropbox account has been reset.<br/>Please re-configure the Dropbox account link.'
+      const message = 'The Dropbox access method has changed.<br/><br/>' +
+                      'Previously a custom folder was used for Dropbox access.<br/>Now we are using app folder access.<br/><br/>' +
+                      'The link to your dropbox account has been reset.<br/>Please re-configure the Dropbox account link.'
 
-        await showDialog('Change of Dropbox Configuration', message);
-      }
+      await showDialog('Change of Dropbox Configuration', message);
     }
 
     await eventController.publishAsync('on-startup-completed');

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -27,6 +27,7 @@ const i18nController = require('./controllers/i18n_controller.js');
 const dbSyncController = require('./controllers/db_sync_controller.js');
 const eventController = require('./controllers/event_controller.js');
 const cacheController = require('./controllers/cache_controller.js');
+const { showDialog } = require('./helpers/ezra_helper.js');
 
 // UI Helper
 const UiHelper = require('./helpers/ui_helper.js');
@@ -451,8 +452,9 @@ class Startup {
 
     console.timeEnd("application-startup");
 
-    // Save some meta data about versions used
+    let lastUsedVersion = await ipcSettings.get('lastUsedVersion');
 
+    // Save some meta data about versions used
     cacheController.saveLastUsedVersion();
 
     if (platformHelper.isCordova()) {
@@ -483,6 +485,23 @@ class Startup {
       const NewReleaseChecker = require('./helpers/new_release_checker.js');
       var newReleaseChecker = new NewReleaseChecker('new-release-info-box');
       newReleaseChecker.check();
+    }
+
+    if (lastUsedVersion != '') {
+      lastUsedVersion = lastUsedVersion.split('.');
+      let lastMajorVersion = parseInt(lastUsedVersion[0]);
+      let lastMinorVersion = parseInt(lastUsedVersion[1]);
+
+      if (lastMajorVersion == 1 && lastMinorVersion < 15) {
+        // The Dropbox access level has changed from full access to app folder access in version 1.15.
+        // Here we inform the user about this change.
+
+        const message = 'The Dropbox access method has changed.<br/><br/>' +
+                        'Previously a custom folder was used for Dropbox access.<br/>Now we are using app folder access.<br/><br/>' +
+                        'The link to your dropbox account has been reset.<br/>Please re-configure the Dropbox account link.'
+
+        await showDialog('Change of Dropbox Configuration', message);
+      }
     }
 
     await eventController.publishAsync('on-startup-completed');

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -493,7 +493,8 @@ class Startup {
 
       const message = 'The Dropbox access method has changed.<br/><br/>' +
                       'Previously a custom folder was used for Dropbox access.<br/>From Ezra Bible App 1.15, app folder access is used.<br/><br/>' +
-                      'The link to your Dropbox account has been reset.<br/>Please re-configure the Dropbox account link.<br/><br/>' +
+                      'The link of Ezra Bible App to your Dropbox account has been reset (No need to worry about data loss!)<br/>' +
+                      'Please re-configure the Dropbox account link.<br/><br/>' +
                       'You need to upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same.';
 
       await showDialog('Change of Dropbox access method', message, 600, 400);

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -491,16 +491,17 @@ class Startup {
       // The Dropbox access level has changed from full access to app folder access in version 1.15.
       // Here we inform the user about this change.
 
-      const message = 'The Dropbox access method has changed!<br/><br/>' +
-                      'Previously a custom folder was used for Dropbox access.<br/>From Ezra Bible App 1.15, app folder access is used.<br/><br/>' +
-                      'The link of Ezra Bible App to your Dropbox account has been reset.<br/>' +
-                      'These are the actions you need to take now:' +
-                      '<ul>' +
-                      '<li>Please re-configure the Dropbox account link.</li>' +
-                      '<li>You need to upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same.</li>' +
-                      '</ul>';
+      const message = ```
+      ${i18n.t('dropbox.access-method-message-part1')}
+      ${i18n.t('dropbox.access-method-message-part2')}
+      ${i18n.t('dropbox.access-method-message-part3')}
+      <ul>
+        <li>${i18n.t('dropbox.access-method-message-part4')}</li>
+        <li>${i18n.t('dropbox.access-method-message-part5')}</li>
+      </ul>
+      ```;
 
-      await showDialog('Change of Dropbox access method', message, 600, 450);
+      await showDialog(i18n.t('dropbox.access-method-change'), message, 600, 450);
     }
 
     await eventController.publishAsync('on-startup-completed');

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -494,9 +494,10 @@ class Startup {
       const message = i18n.t('dropbox.access-method-message-part1') +
                       i18n.t('dropbox.access-method-message-part2') +
                       i18n.t('dropbox.access-method-message-part3') +
+                      i18n.t('dropbox.access-method-message-part4') +
                       `<ul>
-                        <li>${i18n.t('dropbox.access-method-message-part4')}</li>
                         <li>${i18n.t('dropbox.access-method-message-part5')}</li>
+                        <li>${i18n.t('dropbox.access-method-message-part6')}</li>
                       </ul>`;
 
       await showDialog(i18n.t('dropbox.access-method-change'), message, 600, 450);

--- a/css/main.css
+++ b/css/main.css
@@ -1572,8 +1572,7 @@ li.book-unavailable a:focus,
 .tab-search-input,
 .tab-search-type,
 #search-type,
-#search-scope,
-#dropbox-sync-folder {
+#search-scope {
   border: 1px solid lightgray;
   border-radius: 4px;
 }

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -473,10 +473,6 @@ Librem 5/Pinephone etc.
     margin-bottom: 1em !important;
   }
 
-  #dropbox-sync-folder {
-    width: 8em;
-  }
-
   /* Hide keyboard shortcuts on mobile */
   #app-info-tabs-3-nav, #app-info-tabs-3 {
     display: none !important;

--- a/html/boxes.html
+++ b/html/boxes.html
@@ -127,11 +127,6 @@
       <label for="only-sync-on-wifi" i18n="dropbox.only-sync-on-wifi"></label>
       <input id="only-sync-on-wifi" type="checkbox"></input><br/>
     </div>
-
-    <div>
-      <label for="dropbox-sync-folder" i18n="dropbox.dropbox-sync-folder"></label>
-      <input id="dropbox-sync-folder" value="ezra"></input>
-    </div>
   </div>
 </div>
 

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -490,7 +490,7 @@
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
-    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part3": "The new Dropbox folder is /Apps/Ezra Bible App.<br/><br/>",
     "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
     "access-method-message-part5": "These are the actions you need to take now:",
     "access-method-message-part6": "Re-configure the Dropbox account link.",

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -486,6 +486,14 @@
     "last-dropbox-upload-time": "Zuletzt hochgeladen",
     "sync-msg-title": "Dropbox Synchronisation",
     "sync-success-msg": "Datenbank erfolgreich mit Dropbox synchronisiert ({{date}}).",
-    "sync-failed-msg": "Synchronisation mit Dropbox fehlgeschlagen ({{date}})."
+    "sync-failed-msg": "Synchronisation mit Dropbox fehlgeschlagen ({{date}}).",
+    "access-method-change": "Change of Dropbox access method",
+    "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
+    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
+    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
+    "access-method-message-part5": "These are the actions you need to take now:",
+    "access-method-message-part6": "Re-configure the Dropbox account link.",
+    "access-method-message-part7": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -479,7 +479,6 @@
     "dropbox-link-status-linking-failed": "Verbindung fehlgeschlagen!",
     "only-sync-on-wifi": "Nur bei WLAN Verbindung synchronisieren",
     "sync-after-changes": "Datenbank nach Änderungen synchronisieren",
-    "dropbox-sync-folder": "Dropbox Verzeichnis",
     "dropbox-sync-info": "Informationen zur Dropbox Synchronisation",
     "last-dropbox-sync-time": "Zuletzt synchronisiert",
     "last-dropbox-sync-result": "Letztes Synchronisationsergebnis",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -493,10 +493,11 @@
     "sync-failed-msg": "Failed to synchronize database with Dropbox ({{date}}).",
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
-    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/><br/>",
-    "access-method-message-part3": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
-    "access-method-message-part4": "These are the actions you need to take now:",
-    "access-method-message-part5": "Re-configure the Dropbox account link.",
-    "access-method-message-part6": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
+    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
+    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
+    "access-method-message-part5": "These are the actions you need to take now:",
+    "access-method-message-part6": "Re-configure the Dropbox account link.",
+    "access-method-message-part7": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -494,7 +494,7 @@
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
-    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part3": "The new Dropbox folder is /Apps/Ezra Bible App.<br/><br/>",
     "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
     "access-method-message-part5": "These are the actions you need to take now:",
     "access-method-message-part6": "Re-configure the Dropbox account link.",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -483,7 +483,6 @@
     "dropbox-link-status-linking-failed": "Linking failed!",
     "only-sync-on-wifi": "Only sync on WiFi",
     "sync-after-changes": "Sync database after changes",
-    "dropbox-sync-folder": "Dropbox sync folder",
     "dropbox-sync-info": "Dropbox synchronization info",
     "last-dropbox-sync-time": "Last sync",
     "last-dropbox-sync-result": "Last sync result",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -490,6 +490,12 @@
     "last-dropbox-upload-time": "Last upload",
     "sync-msg-title": "Dropbox sync",
     "sync-success-msg": "Successfully synchronized database with Dropbox ({{date}}).",
-    "sync-failed-msg": "Failed to synchronize database with Dropbox ({{date}})."
+    "sync-failed-msg": "Failed to synchronize database with Dropbox ({{date}}).",
+    "access-method-change": "Change of Dropbox access method",
+    "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
+    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/><br/>The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
+    "access-method-message-part3": "These are the actions you need to take now:",
+    "access-method-message-part4": "Please re-configure the Dropbox account link.",
+    "access-method-message-part5": "You need to upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -493,9 +493,10 @@
     "sync-failed-msg": "Failed to synchronize database with Dropbox ({{date}}).",
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
-    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/><br/>The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
-    "access-method-message-part3": "These are the actions you need to take now:",
-    "access-method-message-part4": "Re-configure the Dropbox account link.",
-    "access-method-message-part5": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
+    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/><br/>",
+    "access-method-message-part3": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
+    "access-method-message-part4": "These are the actions you need to take now:",
+    "access-method-message-part5": "Re-configure the Dropbox account link.",
+    "access-method-message-part6": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -495,7 +495,7 @@
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/><br/>The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
     "access-method-message-part3": "These are the actions you need to take now:",
-    "access-method-message-part4": "Please re-configure the Dropbox account link.",
-    "access-method-message-part5": "You need to upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
+    "access-method-message-part4": "Re-configure the Dropbox account link.",
+    "access-method-message-part5": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -494,7 +494,7 @@
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
-    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part3": "The new Dropbox folder is /Apps/Ezra Bible App.<br/><br/>",
     "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
     "access-method-message-part5": "These are the actions you need to take now:",
     "access-method-message-part6": "Re-configure the Dropbox account link.",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -490,6 +490,14 @@
     "last-dropbox-upload-time": "Última carga",
     "sync-msg-title": "Sincronización con Dropbox",
     "sync-success-msg": "Sincronización exitosa de la base de datos con Dropbox ({{date}}).",
-    "sync-failed-msg": "Falló la sincronización de la base de datos con Dropbox ({{date}})."
+    "sync-failed-msg": "Falló la sincronización de la base de datos con Dropbox ({{date}}).",
+    "access-method-change": "Change of Dropbox access method",
+    "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
+    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
+    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
+    "access-method-message-part5": "These are the actions you need to take now:",
+    "access-method-message-part6": "Re-configure the Dropbox account link.",
+    "access-method-message-part7": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -483,7 +483,6 @@
     "dropbox-link-status-linking-failed": "Falló la vinculación!",
     "only-sync-on-wifi": "Solo sincronizar con conexión WiFi",
     "sync-after-changes": "Sincronizar la base de datos al efectuar cambios",
-    "dropbox-sync-folder": "Carpeta de sincronización en Dropbox",
     "dropbox-sync-info": "Información de sincronización",
     "last-dropbox-sync-time": "Última sincronización",
     "last-dropbox-sync-result": "Estado de la última sincronización",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -501,6 +501,14 @@
     "last-dropbox-upload-time": "Dernier mise en ligne",
     "sync-msg-title": "Synchronisation Dropbox",
     "sync-success-msg": "Base de données synchronisée avec succès avec Dropbox ({{date}}).",
-    "sync-failed-msg": "La synchronisation de la base de données avec Dropbox a réussi ({{date}})."
+    "sync-failed-msg": "La synchronisation de la base de données avec Dropbox a réussi ({{date}}).",
+    "access-method-change": "Change of Dropbox access method",
+    "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
+    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
+    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
+    "access-method-message-part5": "These are the actions you need to take now:",
+    "access-method-message-part6": "Re-configure the Dropbox account link.",
+    "access-method-message-part7": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -505,7 +505,7 @@
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
-    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part3": "The new Dropbox folder is /Apps/Ezra Bible App.<br/><br/>",
     "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
     "access-method-message-part5": "These are the actions you need to take now:",
     "access-method-message-part6": "Re-configure the Dropbox account link.",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -494,7 +494,6 @@
     "dropbox-link-status-linking-failed": "Échec de la liaison !",
     "only-sync-on-wifi": "Synchroniser uniquement sur WiFi",
     "sync-after-changes": "Synchroniser la base de données après les modifications",
-    "dropbox-sync-folder": "Dossier de synchronisation Dropbox",
     "dropbox-sync-info": "Informations de synchronisation Dropbox",
     "last-dropbox-sync-time": "Dernière synchronisation",
     "last-dropbox-sync-result": "Résultat de la dernière synchronisation",

--- a/locales/nl/translation.json
+++ b/locales/nl/translation.json
@@ -485,7 +485,6 @@
     "dropbox-link-status-linking-failed": "Koppeling gefaald!",
     "only-sync-on-wifi": "Alleen synchroniseren op WiFi",
     "sync-after-changes": "Synchroniseer databank na wijzigingen",
-    "dropbox-sync-folder": "Dropbox-synchronisatiemap",
     "dropbox-sync-info": "Info over Dropbox-synchronisatie",
     "last-dropbox-sync-time": "Laatste synchronisatie",
     "last-dropbox-sync-result": "Laatste synchronisatieresultaat",

--- a/locales/nl/translation.json
+++ b/locales/nl/translation.json
@@ -492,6 +492,14 @@
     "last-dropbox-upload-time": "Laatste upload",
     "sync-msg-title": "Dropbox-synchronisatie",
     "sync-success-msg": "Synchronisatie van database met Dropbox is gelukt ({{date}}).",
-    "sync-failed-msg": "Synchronisatie van database met Dropbox is mislukt ({{date}})."
+    "sync-failed-msg": "Synchronisatie van database met Dropbox is mislukt ({{date}}).",
+    "access-method-change": "Change of Dropbox access method",
+    "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
+    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
+    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
+    "access-method-message-part5": "These are the actions you need to take now:",
+    "access-method-message-part6": "Re-configure the Dropbox account link.",
+    "access-method-message-part7": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/nl/translation.json
+++ b/locales/nl/translation.json
@@ -496,7 +496,7 @@
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
-    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part3": "The new Dropbox folder is /Apps/Ezra Bible App.<br/><br/>",
     "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
     "access-method-message-part5": "These are the actions you need to take now:",
     "access-method-message-part6": "Re-configure the Dropbox account link.",

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -493,7 +493,7 @@
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
-    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part3": "The new Dropbox folder is /Apps/Ezra Bible App.<br/><br/>",
     "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
     "access-method-message-part5": "These are the actions you need to take now:",
     "access-method-message-part6": "Re-configure the Dropbox account link.",

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -482,7 +482,6 @@
     "dropbox-link-status-linking-failed": "Falha ao vincular!",
     "only-sync-on-wifi": "Sincronizar apenas via Wi-Fi",
     "sync-after-changes": "Sincronizar bando de dados após mudanças",
-    "dropbox-sync-folder": "Pasta de sincronização do Dropbox",
     "dropbox-sync-info": "Informação de sincronização do Dropbox",
     "last-dropbox-sync-time": "Última sincronização",
     "last-dropbox-sync-result": "Resultado da última sincronização",

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -489,6 +489,14 @@
     "last-dropbox-upload-time": "Último upload",
     "sync-msg-title": "Sincronização Dropbox",
     "sync-success-msg": "Sincronização com banco de dados via Dropbox bem sucedida ({{date}}).",
-    "sync-failed-msg": "Falha ao sincronizar banco de dados via Dropbox ({{date}})."
+    "sync-failed-msg": "Falha ao sincronizar banco de dados via Dropbox ({{date}}).",
+    "access-method-change": "Change of Dropbox access method",
+    "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
+    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
+    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
+    "access-method-message-part5": "These are the actions you need to take now:",
+    "access-method-message-part6": "Re-configure the Dropbox account link.",
+    "access-method-message-part7": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/ro/translation.json
+++ b/locales/ro/translation.json
@@ -494,7 +494,7 @@
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
-    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part3": "The new Dropbox folder is /Apps/Ezra Bible App.<br/><br/>",
     "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
     "access-method-message-part5": "These are the actions you need to take now:",
     "access-method-message-part6": "Re-configure the Dropbox account link.",

--- a/locales/ro/translation.json
+++ b/locales/ro/translation.json
@@ -490,6 +490,14 @@
     "last-dropbox-upload-time": "Ultima încărcare",
     "sync-msg-title": "Sincronizare Dropbox",
     "sync-success-msg": "Baza de date a fost sincronizată cu Dropbox cu succes ({{date}}).",
-    "sync-failed-msg": "Nu s-a putut sincroniza baza de date cu Dropbox ({{date}})."
+    "sync-failed-msg": "Nu s-a putut sincroniza baza de date cu Dropbox ({{date}}).",
+    "access-method-change": "Change of Dropbox access method",
+    "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
+    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
+    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
+    "access-method-message-part5": "These are the actions you need to take now:",
+    "access-method-message-part6": "Re-configure the Dropbox account link.",
+    "access-method-message-part7": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/ro/translation.json
+++ b/locales/ro/translation.json
@@ -483,7 +483,6 @@
     "dropbox-link-status-linking-failed": "Conectare eșuată!",
     "only-sync-on-wifi": "Sincronizare doar prin WiFi",
     "sync-after-changes": "Sincronizează bază de date după modificări",
-    "dropbox-sync-folder": "Folder-ul de sincronizarea Dropbox",
     "dropbox-sync-info": "Info sincronizre Dropbox",
     "last-dropbox-sync-time": "Ultima sincronizare",
     "last-dropbox-sync-result": "Rezultat ultima sincronizare",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -486,7 +486,6 @@
     "dropbox-link-status-linking-failed": "Привязка не удалась!",
     "only-sync-on-wifi": "Синхронизация только по WiFi",
     "sync-after-changes": "Синхронизировать базу данных после изменений",
-    "dropbox-sync-folder": "Папка в Dropbox",
     "dropbox-sync-info": "Информация о синхронизации Dropbox",
     "last-dropbox-sync-time": "Синхронизированно",
     "last-dropbox-sync-result": "Результат последней синхронизации",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -493,6 +493,14 @@
     "last-dropbox-upload-time": "Последняя загрузка",
     "sync-msg-title": "Синхронизация Dropbox",
     "sync-success-msg": "Синхронизация базы данных с Dropbox успешна ({{date}}).",
-    "sync-failed-msg": "Не удалось синхронизировать базу данных с Dropbox ({{date}})."
+    "sync-failed-msg": "Не удалось синхронизировать базу данных с Dropbox ({{date}}).",
+    "access-method-change": "Change of Dropbox access method",
+    "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
+    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
+    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
+    "access-method-message-part5": "These are the actions you need to take now:",
+    "access-method-message-part6": "Re-configure the Dropbox account link.",
+    "access-method-message-part7": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -497,7 +497,7 @@
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
-    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part3": "The new Dropbox folder is /Apps/Ezra Bible App.<br/><br/>",
     "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
     "access-method-message-part5": "These are the actions you need to take now:",
     "access-method-message-part6": "Re-configure the Dropbox account link.",

--- a/locales/sk/translation.json
+++ b/locales/sk/translation.json
@@ -494,7 +494,7 @@
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
-    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part3": "The new Dropbox folder is /Apps/Ezra Bible App.<br/><br/>",
     "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
     "access-method-message-part5": "These are the actions you need to take now:",
     "access-method-message-part6": "Re-configure the Dropbox account link.",

--- a/locales/sk/translation.json
+++ b/locales/sk/translation.json
@@ -490,6 +490,14 @@
     "last-dropbox-upload-time": "Posledné nahranie",
     "sync-msg-title": "Synchronizácia Dropboxu",
     "sync-success-msg": "Databáza bola úspešne synchronizovaná s Dropboxom ({{date}}).",
-    "sync-failed-msg": "Synchronizácia databázy s Dropboxom zlyhala ({{date}})."
+    "sync-failed-msg": "Synchronizácia databázy s Dropboxom zlyhala ({{date}}).",
+    "access-method-change": "Change of Dropbox access method",
+    "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
+    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
+    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
+    "access-method-message-part5": "These are the actions you need to take now:",
+    "access-method-message-part6": "Re-configure the Dropbox account link.",
+    "access-method-message-part7": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/sk/translation.json
+++ b/locales/sk/translation.json
@@ -483,7 +483,6 @@
     "dropbox-link-status-linking-failed": "Prepojenie zlyhalo",
     "only-sync-on-wifi": "Synchronizácia len cez WiFi",
     "sync-after-changes": "Synchronizovať databázu po zmenách",
-    "dropbox-sync-folder": "Synchronizačný priečinok Dropbox",
     "dropbox-sync-info": "Informácie o synchronizácii Dropboxu",
     "last-dropbox-sync-time": "Posledná synchronizácia",
     "last-dropbox-sync-result": "Výsledok poslednej synchronizácie",

--- a/locales/sl/translation.json
+++ b/locales/sl/translation.json
@@ -490,6 +490,14 @@
     "last-dropbox-upload-time": "Zadnje nalaganje",
     "sync-msg-title": "Dropbox sinhronizacija",
     "sync-success-msg": "Uspešno sinhronizirana zbirka podatkov s storitvijo Dropbox ({{date}}).",
-    "sync-failed-msg": "Ni uspelo sinhronizirati zbirke podatkov s storitvijo Dropbox ({{date}})."
+    "sync-failed-msg": "Ni uspelo sinhronizirati zbirke podatkov s storitvijo Dropbox ({{date}}).",
+    "access-method-change": "Change of Dropbox access method",
+    "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
+    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
+    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
+    "access-method-message-part5": "These are the actions you need to take now:",
+    "access-method-message-part6": "Re-configure the Dropbox account link.",
+    "access-method-message-part7": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/sl/translation.json
+++ b/locales/sl/translation.json
@@ -494,7 +494,7 @@
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
-    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part3": "The new Dropbox folder is /Apps/Ezra Bible App.<br/><br/>",
     "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
     "access-method-message-part5": "These are the actions you need to take now:",
     "access-method-message-part6": "Re-configure the Dropbox account link.",

--- a/locales/sl/translation.json
+++ b/locales/sl/translation.json
@@ -483,7 +483,6 @@
     "dropbox-link-status-linking-failed": "Povezovanje ni uspelo!",
     "only-sync-on-wifi": "Sinhronizira se samo na brezžičnem omrežju WiFi",
     "sync-after-changes": "Po spremembah sinhroniziraj podatkovno zbirko",
-    "dropbox-sync-folder": "Dropbox sync folder",
     "dropbox-sync-info": "Informacije o sinhronizaciji Dropboxa",
     "last-dropbox-sync-time": "Zadnja sinhronizacija",
     "last-dropbox-sync-result": "Rezultat zadnje sinhronizacije",

--- a/locales/uk/translation.json
+++ b/locales/uk/translation.json
@@ -491,6 +491,14 @@
     "last-dropbox-upload-time": "Вивантажено минулий раз",
     "sync-msg-title": "Позгодження з Dropbox",
     "sync-success-msg": "Базу даних успішно позгодженно з Dropbox ({{date}}).",
-    "sync-failed-msg": "Помилка позгодження бази даних з Dropbox ({{date}})."
+    "sync-failed-msg": "Помилка позгодження бази даних з Dropbox ({{date}}).",
+    "access-method-change": "Change of Dropbox access method",
+    "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
+    "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
+    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
+    "access-method-message-part5": "These are the actions you need to take now:",
+    "access-method-message-part6": "Re-configure the Dropbox account link.",
+    "access-method-message-part7": "Upgrade Ezra Bible App on all your devices to ensure that the Dropbox sync method is the same."
   }
 }

--- a/locales/uk/translation.json
+++ b/locales/uk/translation.json
@@ -495,7 +495,7 @@
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",
-    "access-method-message-part3": "The Dropbox folder used now is /Apps/Ezra Bible App.<br/><br/>",
+    "access-method-message-part3": "The new Dropbox folder is /Apps/Ezra Bible App.<br/><br/>",
     "access-method-message-part4": "The link of Ezra Bible App to your Dropbox account has been reset.<br/>",
     "access-method-message-part5": "These are the actions you need to take now:",
     "access-method-message-part6": "Re-configure the Dropbox account link.",

--- a/locales/uk/translation.json
+++ b/locales/uk/translation.json
@@ -484,7 +484,6 @@
     "dropbox-link-status-linking-failed": "Помилка зв'язування!",
     "only-sync-on-wifi": "Позгоджувати лише через WiFi",
     "sync-after-changes": "Позгоджувати базу даних відразу після змін",
-    "dropbox-sync-folder": "Тека у Dropbox",
     "dropbox-sync-info": "Відомості щодо позгодження з Dropbox",
     "last-dropbox-sync-time": "Останнє позгодження",
     "last-dropbox-sync-result": "Результат останнього позгодження",


### PR DESCRIPTION
* [x] Change Dropbox configuration to use app folder instead of custom folder.
* [x] Reset existing Dropbox connection upon first start of version 1.15.0.
* [x] Show user a dialog at first start of version 1.15.0 with information about the changes in the Dropbox configuration.
* [x] Inform the user about necessary upgrade on all devices. 
* [x] Only show the dialog if the user has already had a working Dropbox configuration.
* [x] Localize the new dialog.
* [x] Update all locales.
* [x] Test on Windows.
* [x] Test on macOS.
* [x] Test on Android.