### PR TITLE
Add option to render Strongs inline

### DIFF
--- a/app/frontend/components/options_menu/options_menu.js
+++ b/app/frontend/components/options_menu/options_menu.js
@@ -103,6 +103,7 @@ class OptionsMenu {
     this._sectionTitleOption = this.initConfigOption('showSectionTitleOption', () => { this.showOrHideSectionTitlesBasedOnOption(); });
     this._xrefsOption = this.initConfigOption('showXrefsOption', () => { this.showOrHideXrefsBasedOnOption(); });
     this._footnotesOption = this.initConfigOption('showFootnotesOption', () => { this.showOrHideFootnotesBasedOnOption(); });
+    this._strongsInlineOption = this.initConfigOption('showStrongsInlineOption', () => { this.showOrHideInlineStrongsBasedOnOption(); });
     this._paragraphsOption = this.initConfigOption('showParagraphsOption', () => { this.showOrHideParagraphsBasedOnOption(); });
     this._redLetterOption = this.initConfigOption('redLetterOption', () => { this.renderRedLettersBasedOnOption(); });
     this._bookChapterNavOption = this.initConfigOption('showBookChapterNavigationOption', () => { this.showOrHideBookChapterNavigationBasedOnOption(); }, bookChapterNavDefault);
@@ -385,6 +386,24 @@ class OptionsMenu {
     }
   }
 
+  showOrHideInlineStrongsBasedOnOption(tabIndex=undefined) {
+    var currentReferenceVerse = referenceVerseController.getCurrentReferenceVerse(tabIndex);
+    var currentVerseList = verseListController.getCurrentVerseList(tabIndex);
+    var tagBoxVerseList = $('#verse-list-popup-verse-list');
+
+    if (currentVerseList[0] != null && currentVerseList[0] != undefined) {
+      if (this._strongsInlineOption.isChecked) {
+        currentReferenceVerse.removeClass('verse-list-without-inline-strongs');
+        currentVerseList.removeClass('verse-list-without-inline-strongs');
+        tagBoxVerseList.removeClass('verse-list-without-inline-strongs');
+      } else {
+        currentReferenceVerse.addClass('verse-list-without-inline-strongs');
+        currentVerseList.addClass('verse-list-without-inline-strongs');
+        tagBoxVerseList.addClass('verse-list-without-inline-strongs');
+      }
+    }
+  }
+
   showOrHideParagraphsBasedOnOption(tabIndex=undefined) {
     var currentReferenceVerse = referenceVerseController.getCurrentReferenceVerse(tabIndex);
     var currentVerseList = verseListController.getCurrentVerseList(tabIndex);
@@ -581,6 +600,7 @@ class OptionsMenu {
     this.showOrHideTabSearchFormBasedOnOption(tabIndex);
     this.showOrHideXrefsBasedOnOption(tabIndex);
     this.showOrHideFootnotesBasedOnOption(tabIndex);
+    this.showOrHideInlineStrongsBasedOnOption(tabIndex);
     this.showOrHideParagraphsBasedOnOption(tabIndex);
     this.renderRedLettersBasedOnOption(tabIndex);
     this.showOrHideUserDataIndicatorsBasedOnOption(tabIndex);

--- a/app/frontend/components/options_menu/options_menu.js
+++ b/app/frontend/components/options_menu/options_menu.js
@@ -47,6 +47,9 @@ class OptionsMenu {
       var CordovaPlatform = require('../../platform/cordova_platform.js');
       this.cordovaPlatform = new CordovaPlatform();
     }
+
+    this.MINIMUM_REFRESH_DISTANCE = 2000;
+    this.lastRefreshViewTime = Date.now() - this.MINIMUM_REFRESH_DISTANCE - 1;
   }
 
   async init() {
@@ -556,7 +559,22 @@ class OptionsMenu {
     await ipcGeneral.setSendCrashReports(window.sendCrashReports);
   }
 
+  
+
   async refreshViewBasedOnOptions(tabIndex=undefined) {
+    const now = Date.now();
+    let timeSinceLastRefresh = 0;
+    
+    if (this.lastRefreshViewTime != 0) {
+      timeSinceLastRefresh = now - this.lastRefreshViewTime;
+    }
+
+    if (timeSinceLastRefresh < this.MINIMUM_REFRESH_DISTANCE) {
+      return;
+    }
+
+    this.lastRefreshViewTime = now;
+
     this.showOrHideBookIntroductionBasedOnOption(tabIndex);
     this.showOrHideSectionTitlesBasedOnOption(tabIndex);
     this.showOrHideBookChapterNavigationBasedOnOption(tabIndex);

--- a/app/frontend/components/options_menu/options_menu.js
+++ b/app/frontend/components/options_menu/options_menu.js
@@ -350,22 +350,38 @@ class OptionsMenu {
     }
   }
 
+  toggleCssClassBasedOnOption(elementList, option, cssClassDisplayNone, addClassWhenOptionChecked=false) {
+    if (elementList == null || elementList.length == 0 || option == null || cssClassDisplayNone == null) {
+      return;
+    }
+
+    elementList.forEach(element => {
+      if (element != null) {
+        if (addClassWhenOptionChecked) {
+          if (option.isChecked) {
+            element.classList.add(cssClassDisplayNone);
+          } else {
+            element.classList.remove(cssClassDisplayNone);
+          }
+        } else {
+          if (option.isChecked) {
+            element.classList.remove(cssClassDisplayNone);
+          } else {
+            element.classList.add(cssClassDisplayNone);
+          }
+        }
+      }
+    });
+  }
+
   showOrHideXrefsBasedOnOption(tabIndex=undefined) {
     var currentReferenceVerse = referenceVerseController.getCurrentReferenceVerse(tabIndex);
     var currentVerseList = verseListController.getCurrentVerseList(tabIndex);
     var tagBoxVerseList = $('#verse-list-popup-verse-list');
 
-    if (currentVerseList[0] != null && currentVerseList[0] != undefined) {
-      if (this._xrefsOption.isChecked) {
-        currentReferenceVerse.removeClass('verse-list-without-xrefs');
-        currentVerseList.removeClass('verse-list-without-xrefs');
-        tagBoxVerseList.removeClass('verse-list-without-xrefs');
-      } else {
-        currentReferenceVerse.addClass('verse-list-without-xrefs');
-        currentVerseList.addClass('verse-list-without-xrefs');
-        tagBoxVerseList.addClass('verse-list-without-xrefs');
-      }
-    }
+    this.toggleCssClassBasedOnOption([currentReferenceVerse[0], currentVerseList[0], tagBoxVerseList[0]],
+                                     this._xrefsOption,
+                                     'verse-list-without-xrefs');
   }
 
   showOrHideFootnotesBasedOnOption(tabIndex=undefined) {
@@ -373,17 +389,9 @@ class OptionsMenu {
     var currentVerseList = verseListController.getCurrentVerseList(tabIndex);
     var tagBoxVerseList = $('#verse-list-popup-verse-list');
 
-    if (currentVerseList[0] != null && currentVerseList[0] != undefined) {
-      if (this._footnotesOption.isChecked) {
-        currentReferenceVerse.removeClass('verse-list-without-footnotes');
-        currentVerseList.removeClass('verse-list-without-footnotes');
-        tagBoxVerseList.removeClass('verse-list-without-footnotes');
-      } else {
-        currentReferenceVerse.addClass('verse-list-without-footnotes');
-        currentVerseList.addClass('verse-list-without-footnotes');
-        tagBoxVerseList.addClass('verse-list-without-footnotes');
-      }
-    }
+    this.toggleCssClassBasedOnOption([currentReferenceVerse[0], currentVerseList[0], tagBoxVerseList[0]],
+                                     this._footnotesOption,
+                                     'verse-list-without-footnotes');
   }
 
   showOrHideStrongsBasedOnOption(tabIndex=undefined) {
@@ -391,17 +399,9 @@ class OptionsMenu {
     var currentVerseList = verseListController.getCurrentVerseList(tabIndex);
     var tagBoxVerseList = $('#verse-list-popup-verse-list');
 
-    if (currentVerseList[0] != null && currentVerseList[0] != undefined) {
-      if (this._strongsOption.isChecked) {
-        currentReferenceVerse.removeClass('verse-list-without-strongs');
-        currentVerseList.removeClass('verse-list-without-strongs');
-        tagBoxVerseList.removeClass('verse-list-without-strongs');
-      } else {
-        currentReferenceVerse.addClass('verse-list-without-strongs');
-        currentVerseList.addClass('verse-list-without-strongs');
-        tagBoxVerseList.addClass('verse-list-without-strongs');
-      }
-    }
+    this.toggleCssClassBasedOnOption([currentReferenceVerse[0], currentVerseList[0], tagBoxVerseList[0]],
+                                     this._strongsOption,
+                                     'verse-list-without-strongs');
   }
 
   showOrHideParagraphsBasedOnOption(tabIndex=undefined) {
@@ -409,17 +409,10 @@ class OptionsMenu {
     var currentVerseList = verseListController.getCurrentVerseList(tabIndex);
     var tagBoxVerseList = $('#verse-list-popup-verse-list');
 
-    if (currentVerseList[0] != null && currentVerseList[0] != undefined) {
-      if (this._paragraphsOption.isChecked) {
-        currentReferenceVerse.addClass('verse-list-with-paragraphs');
-        currentVerseList.addClass('verse-list-with-paragraphs');
-        tagBoxVerseList.addClass('verse-list-with-paragraphs');
-      } else {
-        currentReferenceVerse.removeClass('verse-list-with-paragraphs');
-        currentVerseList.removeClass('verse-list-with-paragraphs');
-        tagBoxVerseList.removeClass('verse-list-with-paragraphs');
-      }
-    }
+    this.toggleCssClassBasedOnOption([currentReferenceVerse[0], currentVerseList[0], tagBoxVerseList[0]],
+                                     this._paragraphsOption,
+                                     'verse-list-with-paragraphs',
+                                     true);
   }
 
   renderRedLettersBasedOnOption(tabIndex=undefined) {
@@ -428,19 +421,10 @@ class OptionsMenu {
     var tagBoxVerseList = $('#verse-list-popup-verse-list');
     var comparePanel = $('#compare-panel');
 
-    if (currentVerseList[0] != null && currentVerseList[0] != undefined) {
-      if (this._redLetterOption.isChecked) {
-        currentReferenceVerse.addClass('verse-list-with-red-letters');
-        currentVerseList.addClass('verse-list-with-red-letters');
-        tagBoxVerseList.addClass('verse-list-with-red-letters');
-        comparePanel.addClass('verse-list-with-red-letters');
-      } else {
-        currentReferenceVerse.removeClass('verse-list-with-red-letters');
-        currentVerseList.removeClass('verse-list-with-red-letters');
-        tagBoxVerseList.removeClass('verse-list-with-red-letters');
-        comparePanel.removeClass('verse-list-with-red-letters');
-      }
-    }
+    this.toggleCssClassBasedOnOption([currentReferenceVerse[0], currentVerseList[0], tagBoxVerseList[0], comparePanel[0]],
+                                     this._redLetterOption,
+                                     'verse-list-with-red-letters',
+                                     true);
   }
 
   showOrHideBookChapterNavigationBasedOnOption(tabIndex=undefined) {
@@ -479,32 +463,18 @@ class OptionsMenu {
     var currentVerseList = verseListController.getCurrentVerseList(tabIndex);
     var currentNavigationPane = app_controller.navigation_pane.getCurrentNavigationPane(tabIndex);
 
-    if (currentVerseList[0] != null && currentVerseList[0] != undefined) {
-      if (this._userDataIndicatorOption.isChecked) {
-        currentReferenceVerse.removeClass('verse-list-without-user-data-indicators');
-        currentVerseList.removeClass('verse-list-without-user-data-indicators');
-        currentNavigationPane.addClass('with-tag-indicators');
-      } else {
-        currentReferenceVerse.addClass('verse-list-without-user-data-indicators');
-        currentVerseList.addClass('verse-list-without-user-data-indicators');
-        currentNavigationPane.removeClass('with-tag-indicators');
-      }
-    }
+    this.toggleCssClassBasedOnOption([currentReferenceVerse[0], currentVerseList[0], currentNavigationPane[0]],
+                                     this._userDataIndicatorOption,
+                                     'verse-list-without-user-data-indicators');
   }
 
   showOrHideVerseTagsBasedOnOption(tabIndex=undefined) {
     var currentReferenceVerse = referenceVerseController.getCurrentReferenceVerse(tabIndex);
     var currentVerseList = verseListController.getCurrentVerseList(tabIndex);
 
-    if (currentVerseList[0] != null && currentVerseList[0] != undefined) {
-      if (this._tagsOption.isChecked) {
-        currentReferenceVerse.removeClass('verse-list-without-tags');
-        currentVerseList.removeClass('verse-list-without-tags');
-      } else {
-        currentReferenceVerse.addClass('verse-list-without-tags');
-        currentVerseList.addClass('verse-list-without-tags');
-      }
-    }
+    this.toggleCssClassBasedOnOption([currentReferenceVerse[0], currentVerseList[0]],
+                                     this._tagsOption,
+                                     'verse-list-without-tags');
   }
 
   applyTagGroupFilterBasedOnOption() {
@@ -519,31 +489,20 @@ class OptionsMenu {
     var currentReferenceVerse = referenceVerseController.getCurrentReferenceVerse(tabIndex);
     var currentVerseList = verseListController.getCurrentVerseList(tabIndex);
 
-    if (currentVerseList[0] != null && currentVerseList[0] != undefined) {
-      if (this._verseNotesOption.isChecked) {
-        currentReferenceVerse.addClass('verse-list-with-notes');
-        currentVerseList.addClass('verse-list-with-notes');
-      } else {
-        app_controller.notes_controller.restoreCurrentlyEditedNotes();
-        currentReferenceVerse.removeClass('verse-list-with-notes');
-        currentVerseList.removeClass('verse-list-with-notes');
-      }
-    }
+    this.toggleCssClassBasedOnOption([currentReferenceVerse[0], currentVerseList[0]],
+                                     this._verseNotesOption,
+                                     'verse-list-with-notes',
+                                     true);
   }
 
   fixNotesHeightBasedOnOption(tabIndex=undefined) {
     var currentReferenceVerse = referenceVerseController.getCurrentReferenceVerse(tabIndex);
     var currentVerseList = verseListController.getCurrentVerseList(tabIndex);
 
-    if (currentVerseList[0] != null && currentVerseList[0] != undefined) {
-      if (this._verseNotesFixedHeightOption.isChecked) {
-        currentReferenceVerse.addClass('verse-list-scroll-notes');
-        currentVerseList.addClass('verse-list-scroll-notes');
-      } else {
-        currentReferenceVerse.removeClass('verse-list-scroll-notes');
-        currentVerseList.removeClass('verse-list-scroll-notes');
-      }
-    }
+    this.toggleCssClassBasedOnOption([currentReferenceVerse[0], currentVerseList[0]],
+                                     this._verseNotesFixedHeightOption,
+                                     'verse-list-scroll-notes',
+                                     true);
   }
 
   keepScreenAwakeBasedOnOption() {
@@ -562,23 +521,16 @@ class OptionsMenu {
     var currentReferenceVerse = referenceVerseController.getCurrentReferenceVerse(tabIndex);
     var currentVerseList = verseListController.getCurrentVerseList(tabIndex);
 
-    if (currentVerseList[0] != null && currentVerseList[0] != undefined) {
-      if (this._tagsColumnOption.isChecked) {
-        currentReferenceVerse.addClass('verse-list-tags-column');
-        currentVerseList.addClass('verse-list-tags-column');
-      } else {
-        currentReferenceVerse.removeClass('verse-list-tags-column');
-        currentVerseList.removeClass('verse-list-tags-column');
-      }
-    }
+    this.toggleCssClassBasedOnOption([currentReferenceVerse[0], currentVerseList[0]],
+                                     this._tagsColumnOption,
+                                     'verse-list-tags-column',
+                                     true);
   }
 
   async toggleCrashReportsBasedOnOption() {
     window.sendCrashReports = this._sendCrashReportsOption.isChecked;
     await ipcGeneral.setSendCrashReports(window.sendCrashReports);
   }
-
-  
 
   async refreshViewBasedOnOptions(tabIndex=undefined) {
     const now = Date.now();

--- a/app/frontend/components/options_menu/options_menu.js
+++ b/app/frontend/components/options_menu/options_menu.js
@@ -103,7 +103,7 @@ class OptionsMenu {
     this._sectionTitleOption = this.initConfigOption('showSectionTitleOption', () => { this.showOrHideSectionTitlesBasedOnOption(); });
     this._xrefsOption = this.initConfigOption('showXrefsOption', () => { this.showOrHideXrefsBasedOnOption(); });
     this._footnotesOption = this.initConfigOption('showFootnotesOption', () => { this.showOrHideFootnotesBasedOnOption(); });
-    this._strongsInlineOption = this.initConfigOption('showStrongsInlineOption', () => { this.showOrHideInlineStrongsBasedOnOption(); });
+    this._strongsOption = this.initConfigOption('showStrongsInlineOption', () => { this.showOrHideStrongsBasedOnOption(); });
     this._paragraphsOption = this.initConfigOption('showParagraphsOption', () => { this.showOrHideParagraphsBasedOnOption(); });
     this._redLetterOption = this.initConfigOption('redLetterOption', () => { this.renderRedLettersBasedOnOption(); });
     this._bookChapterNavOption = this.initConfigOption('showBookChapterNavigationOption', () => { this.showOrHideBookChapterNavigationBasedOnOption(); }, bookChapterNavDefault);
@@ -386,13 +386,13 @@ class OptionsMenu {
     }
   }
 
-  showOrHideInlineStrongsBasedOnOption(tabIndex=undefined) {
+  showOrHideStrongsBasedOnOption(tabIndex=undefined) {
     var currentReferenceVerse = referenceVerseController.getCurrentReferenceVerse(tabIndex);
     var currentVerseList = verseListController.getCurrentVerseList(tabIndex);
     var tagBoxVerseList = $('#verse-list-popup-verse-list');
 
     if (currentVerseList[0] != null && currentVerseList[0] != undefined) {
-      if (this._strongsInlineOption.isChecked) {
+      if (this._strongsOption.isChecked) {
         currentReferenceVerse.removeClass('verse-list-without-inline-strongs');
         currentVerseList.removeClass('verse-list-without-inline-strongs');
         tagBoxVerseList.removeClass('verse-list-without-inline-strongs');
@@ -600,7 +600,7 @@ class OptionsMenu {
     this.showOrHideTabSearchFormBasedOnOption(tabIndex);
     this.showOrHideXrefsBasedOnOption(tabIndex);
     this.showOrHideFootnotesBasedOnOption(tabIndex);
-    this.showOrHideInlineStrongsBasedOnOption(tabIndex);
+    this.showOrHideStrongsBasedOnOption(tabIndex);
     this.showOrHideParagraphsBasedOnOption(tabIndex);
     this.renderRedLettersBasedOnOption(tabIndex);
     this.showOrHideUserDataIndicatorsBasedOnOption(tabIndex);

--- a/app/frontend/components/options_menu/options_menu.js
+++ b/app/frontend/components/options_menu/options_menu.js
@@ -393,13 +393,13 @@ class OptionsMenu {
 
     if (currentVerseList[0] != null && currentVerseList[0] != undefined) {
       if (this._strongsOption.isChecked) {
-        currentReferenceVerse.removeClass('verse-list-without-inline-strongs');
-        currentVerseList.removeClass('verse-list-without-inline-strongs');
-        tagBoxVerseList.removeClass('verse-list-without-inline-strongs');
+        currentReferenceVerse.removeClass('verse-list-without-strongs');
+        currentVerseList.removeClass('verse-list-without-strongs');
+        tagBoxVerseList.removeClass('verse-list-without-strongs');
       } else {
-        currentReferenceVerse.addClass('verse-list-without-inline-strongs');
-        currentVerseList.addClass('verse-list-without-inline-strongs');
-        tagBoxVerseList.addClass('verse-list-without-inline-strongs');
+        currentReferenceVerse.addClass('verse-list-without-strongs');
+        currentVerseList.addClass('verse-list-without-strongs');
+        tagBoxVerseList.addClass('verse-list-without-strongs');
       }
     }
   }

--- a/app/frontend/components/verse_list_popup.js
+++ b/app/frontend/components/verse_list_popup.js
@@ -461,6 +461,10 @@ class VerseListPopup {
       $('#verse-list-popup-verse-list').addClass('verse-list-without-footnotes');
     }
 
+    if (!app_controller.optionsMenu._strongsOption.isChecked) {
+      $('#verse-list-popup-verse-list').addClass('verse-list-without-strongs');
+    }
+
     $('#verse-list-popup-verse-list').html(htmlVerses);
 
     if (this.getCurrentTextType() == 'book') {
@@ -469,7 +473,10 @@ class VerseListPopup {
       bookTaggedVersesCountLabel.text(` (${currentBookVerseCount})`);
     }
 
-    app_controller.sword_notes.initForContainer(document.getElementById('verse-list-popup-verse-list'));
+    const verseList = document.getElementById('verse-list-popup-verse-list');
+    app_controller.sword_notes.initForContainer(verseList);
+    app_controller.dictionary_controller.initStrongsForContainer(verseList);
+
     $('#verse-list-popup-verse-list').show();
   }
 }

--- a/app/frontend/controllers/dictionary_controller.js
+++ b/app/frontend/controllers/dictionary_controller.js
@@ -200,18 +200,33 @@ class DictionaryController {
         await this._handleShiftMouseMove(e);
       });
 
-      if (!wElement.classList.contains('strongsInitDone')) {
-        let strongsIds = this.getStrongsIdsFromStrongsElement(wElement);
-        for (let i = strongsIds.length - 1; i >= 0; i--) {
-          let strongsSup = document.createElement('sup');
-          strongsSup.classList.add('strongs');
-          strongsSup.innerText = strongsIds[i];
-          wElement.insertAdjacentElement('afterend', strongsSup);
-        }
-
-        wElement.classList.add('strongsInitDone');
-      }
+      this.initStrongsSup(wElement);
     });
+  }
+
+  initStrongsForContainer(container) {
+    if (container == null) {
+      return;
+    }
+
+    let wElements = container.querySelectorAll('w');
+    wElements.forEach(wElement => {
+      this.initStrongsSup(wElement);
+    });
+  }
+
+  initStrongsSup(wElement) {
+    if (!wElement.classList.contains('strongsInitDone')) {
+      let strongsIds = this.getStrongsIdsFromStrongsElement(wElement);
+      for (let i = strongsIds.length - 1; i >= 0; i--) {
+        let strongsSup = document.createElement('sup');
+        strongsSup.classList.add('strongs');
+        strongsSup.innerText = strongsIds[i];
+        wElement.insertAdjacentElement('afterend', strongsSup);
+      }
+
+      wElement.classList.add('strongsInitDone');
+    }
   }
 
   async getStrongsEntryWithRawKey(rawKey, normalizedKey=undefined) {

--- a/app/frontend/controllers/dictionary_controller.js
+++ b/app/frontend/controllers/dictionary_controller.js
@@ -80,7 +80,7 @@ class DictionaryController {
       this.runAvailabilityCheck();
     });
 
-    eventController.subscribe('on-bible-text-loaded', (tabIndex) => { 
+    eventController.subscribe('on-bible-text-loaded', (tabIndex) => {
       this.bindAfterBibleTextLoaded(tabIndex);
     });
 
@@ -199,6 +199,18 @@ class DictionaryController {
         currentTab.tab_search.blurInputField();
         await this._handleShiftMouseMove(e);
       });
+
+      if (!wElement.classList.contains('strongsInitDone')) {
+        let strongsIds = this.getStrongsIdsFromStrongsElement(wElement);
+        for (let i = strongsIds.length - 1; i >= 0; i--) {
+          let strongsSup = document.createElement('sup');
+          strongsSup.classList.add('strongs');
+          strongsSup.innerText = strongsIds[i];
+          wElement.insertAdjacentElement('afterend', strongsSup);
+        }
+
+        wElement.classList.add('strongsInitDone');
+      }
     });
   }
 

--- a/app/frontend/helpers/verse_box_helper.js
+++ b/app/frontend/helpers/verse_box_helper.js
@@ -275,6 +275,7 @@ class VerseBoxHelper {
         }
 
         currentText.find('.sword-markup').filter(":not('.sword-quote-jesus, .sword-quote')").remove();
+        currentText.find('sup.strongs').remove();
 
         if (html) {
           this.convertTransChangeToItalic(currentText);

--- a/css/main.css
+++ b/css/main.css
@@ -2094,3 +2094,8 @@ transchange {
 s {
   text-decoration: none;
 }
+
+sup.strongs {
+  margin-left: 0.2em;
+  font-size: 70%;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -2074,6 +2074,10 @@ transchange {
   display: none;
 }
 
+.verse-list-without-inline-strongs sup.strongs {
+  display: none;
+}
+
 .strongs-hl {
   background-color: var(--highlight-bg-color);
 }

--- a/css/main.css
+++ b/css/main.css
@@ -2074,7 +2074,7 @@ transchange {
   display: none;
 }
 
-.verse-list-without-inline-strongs sup.strongs {
+.verse-list-without-strongs sup.strongs {
   display: none;
 }
 

--- a/html/display_options_menu.html
+++ b/html/display_options_menu.html
@@ -68,6 +68,7 @@
   <config-option id="showSectionTitleOption" settingsKey="showSectionTitles" label="bible-browser.show-section-titles" checkedByDefault="true"></config-option>
   <config-option id="showXrefsOption" settingsKey="showXrefs" label="bible-browser.show-xrefs" checkedByDefault="false"></config-option>
   <config-option id="showFootnotesOption" settingsKey="showFootnotes" label="bible-browser.show-footnotes" checkedByDefault="false"></config-option>
+  <config-option id="showStrongsInlineOption" settingsKey="showStrongsInline" label="bible-browser.show-strongs-inline" checkedByDefault="false"></config-option>
   <config-option id="showParagraphsOption" settingsKey="showParagraphs" label="bible-browser.show-paragraphs" checkedByDefault="false"></config-option>
   <config-option id="redLetterOption" settingsKey="redLetters" label="bible-browser.red-letters" checkedByDefault="true"></config-option>
 

--- a/html/display_options_menu.html
+++ b/html/display_options_menu.html
@@ -68,7 +68,7 @@
   <config-option id="showSectionTitleOption" settingsKey="showSectionTitles" label="bible-browser.show-section-titles" checkedByDefault="true"></config-option>
   <config-option id="showXrefsOption" settingsKey="showXrefs" label="bible-browser.show-xrefs" checkedByDefault="false"></config-option>
   <config-option id="showFootnotesOption" settingsKey="showFootnotes" label="bible-browser.show-footnotes" checkedByDefault="false"></config-option>
-  <config-option id="showStrongsInlineOption" settingsKey="showStrongsInline" label="bible-browser.show-strongs-inline" checkedByDefault="false"></config-option>
+  <config-option id="showStrongsInlineOption" settingsKey="showStrongsInline" label="bible-browser.show-strongs" checkedByDefault="false"></config-option>
   <config-option id="showParagraphsOption" settingsKey="showParagraphs" label="bible-browser.show-paragraphs" checkedByDefault="false"></config-option>
   <config-option id="redLetterOption" settingsKey="redLetters" label="bible-browser.red-letters" checkedByDefault="true"></config-option>
 

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -346,6 +346,7 @@
     "show-section-titles": "Zeige Überschriften",
     "show-xrefs": "Zeige Parallelstellen",
     "show-footnotes": "Zeige Fußnoten",
+    "show-strongs-inline": "Show strongs inline",
     "show-paragraphs": "Zeige Absätze",
     "red-letters": "Jesu Worte in rot hervorheben",
     "show-dictionary": "Wörterbuch zeigen",

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -346,7 +346,7 @@
     "show-section-titles": "Zeige Überschriften",
     "show-xrefs": "Zeige Parallelstellen",
     "show-footnotes": "Zeige Fußnoten",
-    "show-strongs-inline": "Show strongs",
+    "show-strongs": "Show strongs",
     "show-paragraphs": "Zeige Absätze",
     "red-letters": "Jesu Worte in rot hervorheben",
     "show-dictionary": "Wörterbuch zeigen",

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -346,7 +346,7 @@
     "show-section-titles": "Zeige Überschriften",
     "show-xrefs": "Zeige Parallelstellen",
     "show-footnotes": "Zeige Fußnoten",
-    "show-strongs-inline": "Show strongs inline",
+    "show-strongs-inline": "Show strongs",
     "show-paragraphs": "Zeige Absätze",
     "red-letters": "Jesu Worte in rot hervorheben",
     "show-dictionary": "Wörterbuch zeigen",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -350,6 +350,7 @@
     "show-section-titles": "Show section titles",
     "show-xrefs": "Show cross references",
     "show-footnotes": "Show footnotes",
+    "show-strongs-inline": "Show Strongs inline",
     "show-paragraphs": "Show paragraphs",
     "red-letters": "Highlight Jesus' words in red",
     "show-dictionary": "Show dictionary",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -350,7 +350,7 @@
     "show-section-titles": "Show section titles",
     "show-xrefs": "Show cross references",
     "show-footnotes": "Show footnotes",
-    "show-strongs-inline": "Show strongs inline",
+    "show-strongs-inline": "Show strongs",
     "show-paragraphs": "Show paragraphs",
     "red-letters": "Highlight Jesus' words in red",
     "show-dictionary": "Show dictionary",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -350,7 +350,7 @@
     "show-section-titles": "Show section titles",
     "show-xrefs": "Show cross references",
     "show-footnotes": "Show footnotes",
-    "show-strongs-inline": "Show Strongs inline",
+    "show-strongs-inline": "Show strongs inline",
     "show-paragraphs": "Show paragraphs",
     "red-letters": "Highlight Jesus' words in red",
     "show-dictionary": "Show dictionary",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -350,7 +350,7 @@
     "show-section-titles": "Show section titles",
     "show-xrefs": "Show cross references",
     "show-footnotes": "Show footnotes",
-    "show-strongs-inline": "Show strongs",
+    "show-strongs": "Show strongs",
     "show-paragraphs": "Show paragraphs",
     "red-letters": "Highlight Jesus' words in red",
     "show-dictionary": "Show dictionary",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -350,6 +350,7 @@
     "show-section-titles": "Mostrar título de secciones",
     "show-xrefs": "Mostrar referencias cruzadas",
     "show-footnotes": "Mostrar notas al pie",
+    "show-strongs-inline": "Show strongs inline",
     "show-paragraphs": "Mostrar párrafos",
     "red-letters": "Remarcar las palabras de Jesús en rojo",
     "show-dictionary": "Mostrar diccionario",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -350,7 +350,7 @@
     "show-section-titles": "Mostrar título de secciones",
     "show-xrefs": "Mostrar referencias cruzadas",
     "show-footnotes": "Mostrar notas al pie",
-    "show-strongs-inline": "Show strongs inline",
+    "show-strongs-inline": "Show strongs",
     "show-paragraphs": "Mostrar párrafos",
     "red-letters": "Remarcar las palabras de Jesús en rojo",
     "show-dictionary": "Mostrar diccionario",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -350,7 +350,7 @@
     "show-section-titles": "Mostrar título de secciones",
     "show-xrefs": "Mostrar referencias cruzadas",
     "show-footnotes": "Mostrar notas al pie",
-    "show-strongs-inline": "Show strongs",
+    "show-strongs": "Show strongs",
     "show-paragraphs": "Mostrar párrafos",
     "red-letters": "Remarcar las palabras de Jesús en rojo",
     "show-dictionary": "Mostrar diccionario",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -360,7 +360,7 @@
     "show-section-titles": "Montrer les titres de sections",
     "show-xrefs": "Montrer les références croisées",
     "show-footnotes": "Afficher les notes de bas de page",
-    "show-strongs-inline": "Show strongs inline",
+    "show-strongs-inline": "Show strongs",
     "show-paragraphs": "Afficher les paragraphes",
     "red-letters": "Surligner les paroles de Jésus en rouge",
     "show-dictionary": "Afficher le dictionnaire",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -360,7 +360,7 @@
     "show-section-titles": "Montrer les titres de sections",
     "show-xrefs": "Montrer les références croisées",
     "show-footnotes": "Afficher les notes de bas de page",
-    "show-strongs-inline": "Show strongs",
+    "show-strongs": "Show strongs",
     "show-paragraphs": "Afficher les paragraphes",
     "red-letters": "Surligner les paroles de Jésus en rouge",
     "show-dictionary": "Afficher le dictionnaire",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -360,6 +360,7 @@
     "show-section-titles": "Montrer les titres de sections",
     "show-xrefs": "Montrer les références croisées",
     "show-footnotes": "Afficher les notes de bas de page",
+    "show-strongs-inline": "Show strongs inline",
     "show-paragraphs": "Afficher les paragraphes",
     "red-letters": "Surligner les paroles de Jésus en rouge",
     "show-dictionary": "Afficher le dictionnaire",

--- a/locales/nl/translation.json
+++ b/locales/nl/translation.json
@@ -352,7 +352,7 @@
     "show-section-titles": "Toon sectietitels",
     "show-xrefs": "Toon kruisverwijzingen",
     "show-footnotes": "Toon voetnoten",
-    "show-strongs-inline": "Show strongs",
+    "show-strongs": "Show strongs",
     "show-paragraphs": "Toon alinea's",
     "red-letters": "Markeer de woorden van Jezus met rood",
     "show-dictionary": "Toon woordenboek",

--- a/locales/nl/translation.json
+++ b/locales/nl/translation.json
@@ -352,6 +352,7 @@
     "show-section-titles": "Toon sectietitels",
     "show-xrefs": "Toon kruisverwijzingen",
     "show-footnotes": "Toon voetnoten",
+    "show-strongs-inline": "Show strongs inline",
     "show-paragraphs": "Toon alinea's",
     "red-letters": "Markeer de woorden van Jezus met rood",
     "show-dictionary": "Toon woordenboek",

--- a/locales/nl/translation.json
+++ b/locales/nl/translation.json
@@ -352,7 +352,7 @@
     "show-section-titles": "Toon sectietitels",
     "show-xrefs": "Toon kruisverwijzingen",
     "show-footnotes": "Toon voetnoten",
-    "show-strongs-inline": "Show strongs inline",
+    "show-strongs-inline": "Show strongs",
     "show-paragraphs": "Toon alinea's",
     "red-letters": "Markeer de woorden van Jezus met rood",
     "show-dictionary": "Toon woordenboek",

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -350,6 +350,7 @@
     "show-section-titles": "Mostrar seção de títulos",
     "show-xrefs": "Mostrar referências cruzadas",
     "show-footnotes": "Mostrar notas de rodapé",
+    "show-strongs-inline": "Show strongs inline",
     "show-paragraphs": "Mostrar parágrafos",
     "red-letters": "Destacar palavras de Jesus em vermelho",
     "show-dictionary": "Mostrar dicionário",

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -350,7 +350,7 @@
     "show-section-titles": "Mostrar seção de títulos",
     "show-xrefs": "Mostrar referências cruzadas",
     "show-footnotes": "Mostrar notas de rodapé",
-    "show-strongs-inline": "Show strongs inline",
+    "show-strongs-inline": "Show strongs",
     "show-paragraphs": "Mostrar parágrafos",
     "red-letters": "Destacar palavras de Jesus em vermelho",
     "show-dictionary": "Mostrar dicionário",

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -350,7 +350,7 @@
     "show-section-titles": "Mostrar seção de títulos",
     "show-xrefs": "Mostrar referências cruzadas",
     "show-footnotes": "Mostrar notas de rodapé",
-    "show-strongs-inline": "Show strongs",
+    "show-strongs": "Show strongs",
     "show-paragraphs": "Mostrar parágrafos",
     "red-letters": "Destacar palavras de Jesus em vermelho",
     "show-dictionary": "Mostrar dicionário",

--- a/locales/ro/translation.json
+++ b/locales/ro/translation.json
@@ -350,6 +350,7 @@
     "show-section-titles": "Afișează titlurile secțiunii",
     "show-xrefs": "Afișează referințe încrucișate",
     "show-footnotes": "Afișează note de subsol",
+    "show-strongs-inline": "Show strongs inline",
     "show-paragraphs": "Afișează paragrafe",
     "red-letters": "Evidențiază cuvintele lui Isus cu roșu.",
     "show-dictionary": "Afișează dicționar",

--- a/locales/ro/translation.json
+++ b/locales/ro/translation.json
@@ -350,7 +350,7 @@
     "show-section-titles": "Afișează titlurile secțiunii",
     "show-xrefs": "Afișează referințe încrucișate",
     "show-footnotes": "Afișează note de subsol",
-    "show-strongs-inline": "Show strongs inline",
+    "show-strongs-inline": "Show strongs",
     "show-paragraphs": "Afișează paragrafe",
     "red-letters": "Evidențiază cuvintele lui Isus cu roșu.",
     "show-dictionary": "Afișează dicționar",

--- a/locales/ro/translation.json
+++ b/locales/ro/translation.json
@@ -350,7 +350,7 @@
     "show-section-titles": "Afișează titlurile secțiunii",
     "show-xrefs": "Afișează referințe încrucișate",
     "show-footnotes": "Afișează note de subsol",
-    "show-strongs-inline": "Show strongs",
+    "show-strongs": "Show strongs",
     "show-paragraphs": "Afișează paragrafe",
     "red-letters": "Evidențiază cuvintele lui Isus cu roșu.",
     "show-dictionary": "Afișează dicționar",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -353,6 +353,7 @@
     "show-section-titles": "Заголовки разделов",
     "show-xrefs": "Перекрестные ссылки",
     "show-footnotes": "Примечания",
+    "show-strongs-inline": "Show strongs inline",
     "show-paragraphs": "Абзацы",
     "red-letters": "Слова Иисуса - красным",
     "show-dictionary": "Словарь",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -353,7 +353,7 @@
     "show-section-titles": "Заголовки разделов",
     "show-xrefs": "Перекрестные ссылки",
     "show-footnotes": "Примечания",
-    "show-strongs-inline": "Show strongs inline",
+    "show-strongs-inline": "Show strongs",
     "show-paragraphs": "Абзацы",
     "red-letters": "Слова Иисуса - красным",
     "show-dictionary": "Словарь",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -353,7 +353,7 @@
     "show-section-titles": "Заголовки разделов",
     "show-xrefs": "Перекрестные ссылки",
     "show-footnotes": "Примечания",
-    "show-strongs-inline": "Show strongs",
+    "show-strongs": "Show strongs",
     "show-paragraphs": "Абзацы",
     "red-letters": "Слова Иисуса - красным",
     "show-dictionary": "Словарь",

--- a/locales/sk/translation.json
+++ b/locales/sk/translation.json
@@ -350,7 +350,7 @@
     "show-section-titles": "Zobraziť názvy sekcií",
     "show-xrefs": "Zobraziť krížové odkazy",
     "show-footnotes": "Zobraziť poznámky pod čiarou",
-    "show-strongs-inline": "Show strongs",
+    "show-strongs": "Show strongs",
     "show-paragraphs": "Zobraziť odseky",
     "red-letters": "Zvýraznite Ježišove slová červenou farbou",
     "show-dictionary": "Zobraziť slovník",

--- a/locales/sk/translation.json
+++ b/locales/sk/translation.json
@@ -350,7 +350,7 @@
     "show-section-titles": "Zobraziť názvy sekcií",
     "show-xrefs": "Zobraziť krížové odkazy",
     "show-footnotes": "Zobraziť poznámky pod čiarou",
-    "show-strongs-inline": "Show strongs inline",
+    "show-strongs-inline": "Show strongs",
     "show-paragraphs": "Zobraziť odseky",
     "red-letters": "Zvýraznite Ježišove slová červenou farbou",
     "show-dictionary": "Zobraziť slovník",

--- a/locales/sk/translation.json
+++ b/locales/sk/translation.json
@@ -350,6 +350,7 @@
     "show-section-titles": "Zobraziť názvy sekcií",
     "show-xrefs": "Zobraziť krížové odkazy",
     "show-footnotes": "Zobraziť poznámky pod čiarou",
+    "show-strongs-inline": "Show strongs inline",
     "show-paragraphs": "Zobraziť odseky",
     "red-letters": "Zvýraznite Ježišove slová červenou farbou",
     "show-dictionary": "Zobraziť slovník",

--- a/locales/sl/translation.json
+++ b/locales/sl/translation.json
@@ -350,7 +350,7 @@
     "show-section-titles": "Prikaži naslove poglavij",
     "show-xrefs": "Prikaži navzkrižne reference",
     "show-footnotes": "Prikaži opombe pod črto",
-    "show-strongs-inline": "Show strongs",
+    "show-strongs": "Show strongs",
     "show-paragraphs": "Prikaži odstavke",
     "red-letters": "Z rdečo barvo označi Jezusove besede",
     "show-dictionary": "Prikaži slovar",

--- a/locales/sl/translation.json
+++ b/locales/sl/translation.json
@@ -350,7 +350,7 @@
     "show-section-titles": "Prikaži naslove poglavij",
     "show-xrefs": "Prikaži navzkrižne reference",
     "show-footnotes": "Prikaži opombe pod črto",
-    "show-strongs-inline": "Show strongs inline",
+    "show-strongs-inline": "Show strongs",
     "show-paragraphs": "Prikaži odstavke",
     "red-letters": "Z rdečo barvo označi Jezusove besede",
     "show-dictionary": "Prikaži slovar",

--- a/locales/sl/translation.json
+++ b/locales/sl/translation.json
@@ -350,6 +350,7 @@
     "show-section-titles": "Prikaži naslove poglavij",
     "show-xrefs": "Prikaži navzkrižne reference",
     "show-footnotes": "Prikaži opombe pod črto",
+    "show-strongs-inline": "Show strongs inline",
     "show-paragraphs": "Prikaži odstavke",
     "red-letters": "Z rdečo barvo označi Jezusove besede",
     "show-dictionary": "Prikaži slovar",

--- a/locales/uk/translation.json
+++ b/locales/uk/translation.json
@@ -351,7 +351,7 @@
     "show-section-titles": "Заголовки розділів",
     "show-xrefs": "Перехресні посилання",
     "show-footnotes": "Примітки",
-    "show-strongs-inline": "Show strongs",
+    "show-strongs": "Show strongs",
     "show-paragraphs": "Абзаци",
     "red-letters": "Слова Ісуса - червоним",
     "show-dictionary": "Словник",

--- a/locales/uk/translation.json
+++ b/locales/uk/translation.json
@@ -351,7 +351,7 @@
     "show-section-titles": "Заголовки розділів",
     "show-xrefs": "Перехресні посилання",
     "show-footnotes": "Примітки",
-    "show-strongs-inline": "Show strongs inline",
+    "show-strongs-inline": "Show strongs",
     "show-paragraphs": "Абзаци",
     "red-letters": "Слова Ісуса - червоним",
     "show-dictionary": "Словник",

--- a/locales/uk/translation.json
+++ b/locales/uk/translation.json
@@ -351,6 +351,7 @@
     "show-section-titles": "Заголовки розділів",
     "show-xrefs": "Перехресні посилання",
     "show-footnotes": "Примітки",
+    "show-strongs-inline": "Show strongs inline",
     "show-paragraphs": "Абзаци",
     "red-letters": "Слова Ісуса - червоним",
     "show-dictionary": "Словник",


### PR DESCRIPTION
This PR addresses #1087.

* [x] Implement rendering of inline strongs.
* [x] Add an option that allows to configure the display of the inline Strongs.
* [x] Update locales with new option.
* [x] Do not include the inline Strongs elements when copying the verse text.
* [x] Consider Strongs option also when rendering verses in popup.
* [x] Fix the test suite.