### PR TITLE
Introduce database backup and automatically recover from corrupt database

### DIFF
--- a/app/backend/database/db_helper.js
+++ b/app/backend/database/db_helper.js
@@ -69,8 +69,8 @@ class DbHelper {
     const backupDbPath = path.join(this.userDataDir, DB_BACKUP_FILE_NAME);
 
     if (fs.existsSync(backupDbPath)) {
-      console.log(`Restoring database backup from ${backupDbPath} at ${dbPath}`);
 
+      console.log(`Restoring database backup from ${backupDbPath} at ${dbPath}`);
       fs.copySync(backupDbPath, dbPath);
 
       return true;

--- a/app/backend/database/db_helper.js
+++ b/app/backend/database/db_helper.js
@@ -35,29 +35,33 @@ class DbHelper {
     this.userDataDir = userDataDir;
   }
 
-  async initDatabase(databaseDir, androidVersion=undefined) {
+  async initDatabase(databaseDir, androidVersion=undefined, reset=false) {
+    const dbFileName = 'ezra.sqlite';
+    const dbPath = path.join(this.userDataDir, dbFileName);
+
+    if (fs.existsSync(dbPath) && reset) {
+      const now = Date.now();
+      let dbBackupFileName = `ezra-${now}.sqlite`;
+      let dbBackupPath = path.join(this.userDataDir, dbBackupFileName);
+
+      console.warn('Resetting database.')
+      console.log(`Renaming corrupt database file to ${dbBackupPath}`);
+      fs.moveSync(dbPath, dbBackupPath);
+    }
+
     this.initDbInUserDir(androidVersion);
     await this.migrateDatabase(databaseDir);
   }
 
   initDbInUserDir(androidVersion=undefined) {
-    var dbFileName = 'ezra.sqlite';
-    var dbPath = path.join(this.userDataDir, dbFileName);
-
-    var oldUserDataDir = this.platformHelper.getUserDataPath(true, androidVersion);
-    var oldDbPath = path.join(oldUserDataDir, dbFileName);
+    const dbFileName = 'ezra.sqlite';
+    const dbPath = path.join(this.userDataDir, dbFileName);
 
     if (!fs.existsSync(dbPath)) {
       console.log('Database not yet existing in user directory!');
-  
-      if (fs.existsSync(oldDbPath)) {
-        console.log(`Copying database from previously used application directory ${oldDbPath}.`);
-        fs.copySync(oldDbPath, dbPath);
-      } else {
-        console.log('Setting up empty database from template.');
-        var templatePath = path.join(__dirname, '../../../ezra.sqlite');
-        fs.copySync(templatePath, dbPath);
-      }
+      console.log('Setting up empty database from template.');
+      const templatePath = path.join(__dirname, '../../../ezra.sqlite');
+      fs.copySync(templatePath, dbPath);
     }
   }
 

--- a/app/backend/database/db_helper.js
+++ b/app/backend/database/db_helper.js
@@ -53,6 +53,16 @@ class DbHelper {
     await this.migrateDatabase(databaseDir);
   }
 
+  async createDatabaseBackup() {
+    const dbFileName = 'ezra.sqlite';
+    const backupDbFileName = 'ezra-backup.sqlite';
+    const dbPath = path.join(this.userDataDir, dbFileName);
+    const backupDbPath = path.join(this.userDataDir, backupDbFileName);
+
+    console.log(`Creating database backup at ${backupDbPath}`);
+    fs.copySync(dbPath, backupDbPath);
+  }
+
   initDbInUserDir(androidVersion=undefined) {
     const dbFileName = 'ezra.sqlite';
     const dbPath = path.join(this.userDataDir, dbFileName);

--- a/app/backend/database/db_helper.js
+++ b/app/backend/database/db_helper.js
@@ -38,8 +38,8 @@ class DbHelper {
     this.userDataDir = userDataDir;
   }
 
-  async initDatabase(databaseDir, androidVersion=undefined) {
-    this.initDbInUserDir(androidVersion);
+  async initDatabase(databaseDir) {
+    this.initDbInUserDir();
     await this.migrateDatabase(databaseDir);
   }
 
@@ -79,7 +79,7 @@ class DbHelper {
     }
   }
 
-  initDbInUserDir(androidVersion=undefined) {
+  initDbInUserDir() {
     const dbPath = path.join(this.userDataDir, DB_FILE_NAME);
 
     if (!fs.existsSync(dbPath)) {

--- a/app/backend/db_sync/dropbox_sync.js
+++ b/app/backend/db_sync/dropbox_sync.js
@@ -91,7 +91,7 @@ class DropboxSync {
   async syncFileTwoWay(filePath, dropboxPath, prioritizeRemote=false) {
     if (!fs.existsSync(filePath)) {
       console.warn(`File ${filePath} does not exist!`);
-      return -4;
+      return -5;
     }
 
     let isSynced = null;
@@ -101,7 +101,7 @@ class DropboxSync {
     } catch (e) {
       console.log(e);
       console.warn(`Could not determine sync status for ${filePath}`);
-      return -5;
+      return -6;
     }
 
     let returnValue = null;
@@ -152,13 +152,20 @@ class DropboxSync {
           returnValue = -2;
         }
       }
-        
+
       if (this.isFileSynced(filePath, dropboxPath)) {
         console.log(`Local file ${filePath} in sync with Dropbox file at ${dropboxPath}.`);
       } else {
         console.warn(`Error syncing local file ${filePath} to Dropbox file at ${dropboxPath}`);
         if (returnValue == null) {
           returnValue = -3;
+        }
+
+        if (returnValue == 2 || returnValue == -2) {
+          // We performed an upload and afterwards the file was detected as not in sync.
+          // This indicates that there has been a serious issue while uploading the file.
+          // The file on Dropbox may be corrupted.
+          returnValue = -4;
         }
       }
     }

--- a/app/backend/ipc/ipc.js
+++ b/app/backend/ipc/ipc.js
@@ -56,6 +56,8 @@ class IPC {
   }
 
   async init(isDebug, electronMainWindow=undefined, androidVersion=undefined) {
+    let returnCode = 0;
+
     if (!global.ipcInitialized) {
       global.ipcInitialized = true;
       let customSwordDir = undefined;
@@ -78,14 +80,17 @@ class IPC {
       if (this.platformHelper.isElectron()) {
         global.ipcNsiHandler.setMainWindow(electronMainWindow);
 
-        await this.initDatabase(isDebug);
+        returnCode = await this.initDatabase(isDebug);
       }
     }
+
+    return returnCode;
   }
 
   async initDatabase(isDebug, androidVersion=undefined, connectionType=undefined) {
     global.ipcDbHandler = new IpcDbHandler();
-    await global.ipcDbHandler.initDatabase(isDebug, androidVersion, connectionType);
+    let returnCode = await global.ipcDbHandler.initDatabase(isDebug, androidVersion, connectionType);
+    return returnCode;
   }
 
   async closeDatabase() {

--- a/app/backend/ipc/ipc_db_handler.js
+++ b/app/backend/ipc/ipc_db_handler.js
@@ -308,9 +308,13 @@ class IpcDbHandler {
 
   triggerDatabaseReload() {
     if (this.platformHelper.isElectron()) {
+      console.log('Triggering database reload ...');
       global.mainWindow.webContents.send('database-updated');
     } else if (this.platformHelper.isCordova()) {
-      cordova.channel.post('database-updated', '');
+      setTimeout(() => {
+        console.log('Triggering database reload ...');
+        cordova.channel.post('database-updated', '');
+      }, 10000);
     }
   }
 

--- a/app/backend/ipc/ipc_db_handler.js
+++ b/app/backend/ipc/ipc_db_handler.js
@@ -90,6 +90,7 @@ class IpcDbHandler {
 
     try {
       await dbHelper.initDatabase(this.dbDir, androidVersion);
+      await dbHelper.createDatabaseBackup();
 
     } catch (exception) {
       console.error(`Could not initialize database at ${this.dbDir} (${exception.name}). Attempting a reset of the database while keeping the potentially corrupt file.`);

--- a/app/frontend/platform/cordova_platform.js
+++ b/app/frontend/platform/cordova_platform.js
@@ -269,7 +269,7 @@ class CordovaPlatform {
 
     nodejs.startWithScript(`
 
-      const Main = require('main.js');
+      const Main = require('cordova_main.js');
 
       global.main = new Main();
       main.init(${isDebug});

--- a/app/frontend/platform/cordova_platform.js
+++ b/app/frontend/platform/cordova_platform.js
@@ -311,9 +311,9 @@ class CordovaPlatform {
     await ipcGeneral.initPersistentIpc(androidVersion);
 
     uiHelper.updateLoadingSubtitle("cordova.init-database", "Initializing database");
-    await ipcGeneral.initDatabase(androidVersion, navigator.connection.type);
+    let initDbResult = await ipcGeneral.initDatabase(androidVersion, navigator.connection.type);
 
-    await startup.initApplication();
+    await startup.initApplication(initDbResult);
   }
 
   mainProcessListener(message) {

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -343,7 +343,18 @@ class Startup {
       await ipcRenderer.send('manageWindowState');
 
       console.log("Initializing IPC handlers ...");
-      await ipcRenderer.invoke('initIpc');
+      let initResult = await ipcRenderer.invoke('initIpc');
+
+      if (initResult < 0) {
+        console.log("WARNING: An error happened during the initialization.");
+
+        if (initResult == -1) {
+          console.error("WARNING: The database file has been reset after corruption.")
+          // Todo: Give a warning message to the user based on this event.
+        } else if (initResult == -2) {
+          console.error("FATAL: The database could not be initialized, even after resetting it due to corruption.");
+        }
+      }
     }
 
     var loadingIndicator = $('#startup-loading-indicator');

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -319,7 +319,7 @@ class Startup {
     });
   }
 
-  async initApplication() {
+  async initApplication(initDbResult=0) {
     console.time("application-startup");
 
     // Wait for the UI to render
@@ -336,8 +336,6 @@ class Startup {
       };
     }
 
-    let initResult = 0;
-
     if (this._platformHelper.isElectron()) {
       window.app = require('@electron/remote').app;
 
@@ -345,7 +343,7 @@ class Startup {
       await ipcRenderer.send('manageWindowState');
 
       console.log("Initializing IPC handlers ...");
-      initResult = await ipcRenderer.invoke('initIpc');
+      initDbResult = await ipcRenderer.invoke('initIpc');
     }
 
     var loadingIndicator = $('#startup-loading-indicator');
@@ -509,19 +507,17 @@ class Startup {
       await showDialog(i18n.t('dropbox.access-method-change'), message, 600, 450);
     }
 
-    if (platformHelper.isElectron()) {
-      this.showDatabaseErrorsIfAny(initResult);
-    }
+    this.showDatabaseErrorsIfAny(initDbResult);
 
     await eventController.publishAsync('on-startup-completed');
     app_controller.startupCompleted = true;
   }
 
-  showDatabaseErrorsIfAny(initResult) {
-    if (initResult < 0) {
+  showDatabaseErrorsIfAny(initDbResult) {
+    if (initDbResult < 0) {
       console.log("WARNING: An error happened during the initialization.");
 
-      if (initResult == -1) {
+      if (initDbResult == -1) {
 
         const message = "The database file has been restored from the last backup after corruption.";
         console.error(message);
@@ -533,7 +529,7 @@ class Startup {
           timeout: 30000
         });
 
-      } else if (initResult == -2) {
+      } else if (initDbResult == -2) {
 
         const message = "The database file was corrupted. A new database has been restored from the initial, empty template.";
         console.error(message);
@@ -545,7 +541,7 @@ class Startup {
           timeout: 30000
         });
 
-      } else if (initResult == -3) {
+      } else if (initDbResult == -3) {
 
         const message = "The database could not be initialized, even after resetting it due to corruption. You should reinstall the app.";
         console.error(message);

--- a/app/frontend/startup.js
+++ b/app/frontend/startup.js
@@ -445,7 +445,10 @@ class Startup {
     // FIXME: Also highlight the last navigation element in the navigation pane and scroll to it
 
     dbSyncController.init();
-    dbSyncController.showSyncResultMessage();
+
+    setTimeout(() => {
+      dbSyncController.showSyncResultMessage();
+    }, 3000);
 
     if (this._platformHelper.isElectron()) {
       const { ipcRenderer } = require('electron');

--- a/app/lib/platform_helper.js
+++ b/app/lib/platform_helper.js
@@ -302,7 +302,17 @@ class PlatformHelper {
     } else if (this.isCordova()) {
       return 100;
     } 
-  } 
+  }
+
+  getIziPosition() {
+    let msgPosition = 'bottomRight';
+
+    if (this.isCordova()) {
+      msgPosition = 'topCenter';
+    }
+
+    return msgPosition;
+  }
 }
 
 module.exports = PlatformHelper;

--- a/cordova_main.js
+++ b/cordova_main.js
@@ -1,0 +1,129 @@
+/* This file is part of Ezra Bible App.
+
+   Copyright (C) 2019 - 2024 Tobias Klein <contact@ezra-project.net>
+
+   Ezra Bible App is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
+
+   Ezra Bible App is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Ezra Project. See the file LICENSE.
+   If not, see <http://www.gnu.org/licenses/>. */
+
+const PlatformHelper = require('./app/lib/platform_helper.js');
+const IPC = require('./app/backend/ipc/ipc.js');
+global.ipc = null;
+global.sendCrashReports = true;
+
+class Main {
+  init(isDebug) {
+    // Require the 'cordova-bridge' to enable communications between the
+    // Node.js app and the Cordova app.
+    global.cordova = require('cordova-bridge');
+    this.platformHelper = new PlatformHelper();
+    this.isDebug = isDebug;
+    this.androidVersion = null;
+
+    if (!isDebug) {
+      this.initSentry();
+    }
+
+    this.initAppEvents();
+
+    global.ipc = new IPC();
+    global.ipc.initNonPersistentIpc();
+
+    const dataDir = cordova.app.datadir();
+
+    cordova.channel.send(`nodejs: main.js loaded / data dir: ${dataDir}`);
+  }
+
+  initSentry() {
+    var pjson = require('./package.json');
+    var version = pjson.version;
+    console.log("Configuring Sentry (node.js) with app version: " + version);
+
+    try {
+      // Loading Sentry in a try/catch block, because we have observed failures related to this step.
+      // If it fails ... startup is broken. Why did it fail previously? After a sentry upgrade the
+      // path to the sources had changed and the require statement did not work anymore.
+
+      global.Sentry = require('@sentry/node/dist');
+
+      Sentry.init({
+        dsn: 'https://977e321b83ec4e47b7d28ffcbdf0c6a1@sentry.io/1488321',
+        release: version,
+        beforeSend: (event) => global.sendCrashReports ? event : null
+      });
+    } catch (error) {
+      console.error('Sentry initialization failed with an error!');
+      console.log(error);
+    }
+  }
+
+  initPersistentIpc(androidVersion=undefined) {
+    console.log("Initializing persistent IPC!");
+
+    this.androidVersion = androidVersion;
+
+    this.initStorage(androidVersion);
+    global.ipc.init(this.isDebug, undefined, androidVersion);
+
+    return true;
+  }
+
+  async initDatabase(androidVersion=undefined, connectionType=undefined) {
+    console.log("Initializing database!");
+    console.log(`Connection type: ${connectionType}`);
+
+    if (connectionType === undefined) {
+      connectionType = global.connectionType;
+    }
+
+    let initDbResult = await global.ipc.initDatabase(this.isDebug, androidVersion, connectionType);
+
+    return initDbResult;
+  }
+
+  async closeDatabase() {
+    await global.ipc.closeDatabase();
+  }
+
+  initAppEvents() {
+    // Handle the 'pause' and 'resume' events.
+    // These are events raised automatically when the app switched to the
+    // background/foreground.
+    cordova.app.on('pause', async (pauseLock) => {
+      console.log('[node] App paused. Closing database!');
+      await this.closeDatabase();
+      console.log('[node] Database closed!');
+      pauseLock.release();
+    });
+
+    cordova.app.on('resume', () => {
+      console.log('[node] Resume: Re-initializing database.');
+      this.initDatabase(this.androidVersion);
+
+      console.log('[node] App resumed.');
+      cordova.channel.post('engine', 'resumed');
+    });
+  }
+
+  initStorage(androidVersion=undefined) {
+    const fs = require('fs');
+    var path = this.platformHelper.getUserDataPath(false, androidVersion);
+
+    if (!fs.existsSync(path)) {
+      console.log("Creating data directory for app at " + path);
+      fs.mkdirSync(path, { recursive: true });
+    }
+  }
+}
+
+module.exports = Main;

--- a/cordova_main.js
+++ b/cordova_main.js
@@ -41,7 +41,7 @@ class Main {
 
     const dataDir = cordova.app.datadir();
 
-    cordova.channel.send(`nodejs: main.js loaded / data dir: ${dataDir}`);
+    cordova.channel.send(`nodejs: cordova_main.js loaded / data dir: ${dataDir}`);
   }
 
   initSentry() {

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -486,7 +486,7 @@
     "last-dropbox-upload-time": "Zuletzt hochgeladen",
     "sync-msg-title": "Dropbox Synchronisation",
     "sync-success-msg": "Datenbank erfolgreich mit Dropbox synchronisiert ({{date}}).",
-    "sync-failed-msg": "Synchronisation mit Dropbox fehlgeschlagen ({{date}}).",
+    "sync-failed-msg": "Synchronisation mit Dropbox fehlgeschlagen ({{date}}: {{syncResult}}).",
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -490,7 +490,7 @@
     "last-dropbox-upload-time": "Last upload",
     "sync-msg-title": "Dropbox sync",
     "sync-success-msg": "Successfully synchronized database with Dropbox ({{date}}).",
-    "sync-failed-msg": "Failed to synchronize database with Dropbox ({{date}}).",
+    "sync-failed-msg": "Failed to synchronize database with Dropbox ({{date}}: {{syncResult}}).",
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -490,7 +490,7 @@
     "last-dropbox-upload-time": "Última carga",
     "sync-msg-title": "Sincronización con Dropbox",
     "sync-success-msg": "Sincronización exitosa de la base de datos con Dropbox ({{date}}).",
-    "sync-failed-msg": "Falló la sincronización de la base de datos con Dropbox ({{date}}).",
+    "sync-failed-msg": "Falló la sincronización de la base de datos con Dropbox ({{date}}: {{syncResult}}).",
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -501,7 +501,7 @@
     "last-dropbox-upload-time": "Dernier mise en ligne",
     "sync-msg-title": "Synchronisation Dropbox",
     "sync-success-msg": "Base de données synchronisée avec succès avec Dropbox ({{date}}).",
-    "sync-failed-msg": "La synchronisation de la base de données avec Dropbox a réussi ({{date}}).",
+    "sync-failed-msg": "La synchronisation de la base de données avec Dropbox a réussi ({{date}}: {{syncResult}}).",
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",

--- a/locales/nl/translation.json
+++ b/locales/nl/translation.json
@@ -492,7 +492,7 @@
     "last-dropbox-upload-time": "Laatste upload",
     "sync-msg-title": "Dropbox-synchronisatie",
     "sync-success-msg": "Synchronisatie van database met Dropbox is gelukt ({{date}}).",
-    "sync-failed-msg": "Synchronisatie van database met Dropbox is mislukt ({{date}}).",
+    "sync-failed-msg": "Synchronisatie van database met Dropbox is mislukt ({{date}}: {{syncResult}}).",
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",

--- a/locales/pt-BR/translation.json
+++ b/locales/pt-BR/translation.json
@@ -489,7 +489,7 @@
     "last-dropbox-upload-time": "Último upload",
     "sync-msg-title": "Sincronização Dropbox",
     "sync-success-msg": "Sincronização com banco de dados via Dropbox bem sucedida ({{date}}).",
-    "sync-failed-msg": "Falha ao sincronizar banco de dados via Dropbox ({{date}}).",
+    "sync-failed-msg": "Falha ao sincronizar banco de dados via Dropbox ({{date}}: {{syncResult}}).",
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",

--- a/locales/ro/translation.json
+++ b/locales/ro/translation.json
@@ -490,7 +490,7 @@
     "last-dropbox-upload-time": "Ultima încărcare",
     "sync-msg-title": "Sincronizare Dropbox",
     "sync-success-msg": "Baza de date a fost sincronizată cu Dropbox cu succes ({{date}}).",
-    "sync-failed-msg": "Nu s-a putut sincroniza baza de date cu Dropbox ({{date}}).",
+    "sync-failed-msg": "Nu s-a putut sincroniza baza de date cu Dropbox ({{date}}: {{syncResult}}).",
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -493,7 +493,7 @@
     "last-dropbox-upload-time": "Последняя загрузка",
     "sync-msg-title": "Синхронизация Dropbox",
     "sync-success-msg": "Синхронизация базы данных с Dropbox успешна ({{date}}).",
-    "sync-failed-msg": "Не удалось синхронизировать базу данных с Dropbox ({{date}}).",
+    "sync-failed-msg": "Не удалось синхронизировать базу данных с Dropbox ({{date}}: {{syncResult}}).",
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",

--- a/locales/sk/translation.json
+++ b/locales/sk/translation.json
@@ -490,7 +490,7 @@
     "last-dropbox-upload-time": "Posledné nahranie",
     "sync-msg-title": "Synchronizácia Dropboxu",
     "sync-success-msg": "Databáza bola úspešne synchronizovaná s Dropboxom ({{date}}).",
-    "sync-failed-msg": "Synchronizácia databázy s Dropboxom zlyhala ({{date}}).",
+    "sync-failed-msg": "Synchronizácia databázy s Dropboxom zlyhala ({{date}}: {{syncResult}}).",
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",

--- a/locales/sl/translation.json
+++ b/locales/sl/translation.json
@@ -490,7 +490,7 @@
     "last-dropbox-upload-time": "Zadnje nalaganje",
     "sync-msg-title": "Dropbox sinhronizacija",
     "sync-success-msg": "Uspešno sinhronizirana zbirka podatkov s storitvijo Dropbox ({{date}}).",
-    "sync-failed-msg": "Ni uspelo sinhronizirati zbirke podatkov s storitvijo Dropbox ({{date}}).",
+    "sync-failed-msg": "Ni uspelo sinhronizirati zbirke podatkov s storitvijo Dropbox ({{date}}: {{syncResult}}).",
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",

--- a/locales/uk/translation.json
+++ b/locales/uk/translation.json
@@ -491,7 +491,7 @@
     "last-dropbox-upload-time": "Вивантажено минулий раз",
     "sync-msg-title": "Позгодження з Dropbox",
     "sync-success-msg": "Базу даних успішно позгодженно з Dropbox ({{date}}).",
-    "sync-failed-msg": "Помилка позгодження бази даних з Dropbox ({{date}}).",
+    "sync-failed-msg": "Помилка позгодження бази даних з Dropbox ({{date}}: {{syncResult}}).",
     "access-method-change": "Change of Dropbox access method",
     "access-method-message-part1": "The Dropbox access method has changed!<br/><br/>Previously a custom folder was used for Dropbox access.<br/>",
     "access-method-message-part2": "From Ezra Bible App 1.15, app folder access is used.<br/>",

--- a/main.js
+++ b/main.js
@@ -163,7 +163,8 @@ async function createWindow(firstStart=true) {
 
     // eslint-disable-next-line no-unused-vars
     ipcMain.handle('initIpc', async (event, arg) => {
-      await global.ipc.init(isDev, global.mainWindow);
+      let returnCode = await global.ipc.init(isDev, global.mainWindow);
+      return returnCode;
     });
 
     // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
This PR closes #1096.

* [x] GIVEN the database is successfully loaded, WHEN the app starts up, THEN a copy of the database shall be created so that a valid backup is available in case of future database corruption.
* [x] GIVEN the remote Dropbox file is corrupted, WHEN the app starts up, THEN the current local file shall be used and a message shall be shown to the user about the corrupted remote file.
* [x] GIVEN the database is corrupted, WHEN the app starts up, THEN the corrupted database file should be renamed and the app shall restore the last valid database file and show a clear message to the user after startup.
* [x] Test on Desktop.
* [x] Test on Android.