### PR TITLE
Update electron -> 28.0.0 to improve note taking under Wayland

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "chai-as-promised": "^7.1.1",
     "copy-dir": "^1.3.0",
     "cucumber": "^6.0.5",
-    "electron": "^17.1.0",
+    "electron": "^28.0.0",
     "@electron/osx-sign": "^1.0.5",
     "electron-packager": "^17.0.0",
     "@electron/rebuild": "^3.6.0",


### PR DESCRIPTION
Using Ezra on Linux using the Wayland windowing system creates lag and stuttering when typing notes. See this video (I'm typing at a constant rate):

[Screencast from 2024-11-03 17-42-00.webm](https://github.com/user-attachments/assets/d47b512e-826c-4e63-af68-23c9023bb978)

Unfortunately, this is due to rendering issues in Chromium rather than configuration issues in the app. In my testing, Electron v28 was the oldest version that supports Wayland in a usable way. This is not only due to rendering improvements (this is the first version without stutter), but also support for window decorations in Wayland (see: https://releases.electronjs.org/release/v28.0.0). I ran the test suite before and after upgrading electron on Linux and it produced the same results when running in X11. However, the test suite does not currently run on Wayland. My guess is that this has something to do with screenshots which are handled very differently in the two systems. I realize there may be other changes needed related to such a large jump, so let me know if there's any other work needed. Everything worked well for me.