### PR TITLE
Increment node-sword-interface to version 1.0.37 to fix unreliable search

### DIFF
--- a/app/frontend/components/tab_search/single_word_highlighter.js
+++ b/app/frontend/components/tab_search/single_word_highlighter.js
@@ -69,7 +69,9 @@ class SingleWordHighlighter {
         }
       }
 
-      if (foundClosingAngleBracketIndex == (i - 1)) {
+      // Disabled for now, because it has been causing issues with highlighting.
+
+      /*if (foundClosingAngleBracketIndex == (i - 1)) {
         // We previously found a closing angle bracket ('</').
 
         if (currentChar == 'd') {
@@ -80,7 +82,7 @@ class SingleWordHighlighter {
           matchIsValid = false;
           break;
         }
-      }
+      }*/
       
       if (currentChar == '<') {
         foundOpeningAngleBracketIndex = i;

--- a/features/005_module_search.feature
+++ b/features/005_module_search.feature
@@ -27,4 +27,4 @@ Feature: Module search
     And I enter the term "faith"
     When I perform the search
     Then the tab title is "Search: faith [KJV]"
-    And there are 324 search results
+    And there are 338 search results

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "log-timestamp": "^0.3.0",
     "marked": "^4.0.8",
     "mousetrap": "^1.6.5",
-    "node-sword-interface": "^1.0.35",
+    "node-sword-interface": "^1.0.36",
     "pug": "^3.0.0",
     "remove-markdown": "^0.3.0",
     "sanitize-html": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "log-timestamp": "^0.3.0",
     "marked": "^4.0.8",
     "mousetrap": "^1.6.5",
-    "node-sword-interface": "^1.0.36",
+    "node-sword-interface": "^1.0.37",
     "pug": "^3.0.0",
     "remove-markdown": "^0.3.0",
     "sanitize-html": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "log-timestamp": "^0.3.0",
     "marked": "^4.0.8",
     "mousetrap": "^1.6.5",
-    "node-sword-interface": "^1.0.34",
+    "node-sword-interface": "^1.0.35",
     "pug": "^3.0.0",
     "remove-markdown": "^0.3.0",
     "sanitize-html": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "log-timestamp": "^0.3.0",
     "marked": "^4.0.8",
     "mousetrap": "^1.6.5",
-    "node-sword-interface": "^1.0.33",
+    "node-sword-interface": "^1.0.34",
     "pug": "^3.0.0",
     "remove-markdown": "^0.3.0",
     "sanitize-html": "^2.13.0",


### PR DESCRIPTION
This fixes the unreliable search function reported in #1210.